### PR TITLE
[FEAT] 가게 상세 메뉴 탭 조회 API 구현

### DIFF
--- a/src/modules/shops/dto/shop-home.dto.ts
+++ b/src/modules/shops/dto/shop-home.dto.ts
@@ -1,0 +1,23 @@
+import { ShopLinkType } from '@prisma/client';
+
+export type ShopHomeDto = {
+  shopId: string;
+  name: string;
+  address: {
+    road: string | null;
+    jibun: string | null;
+  };
+  telephone: string | null;
+  hoursRaw: string | null;
+  links: {
+    website: string | null;
+    instagram: string | null;
+    kakao: string | null;
+    etc: Array<{
+      type: ShopLinkType;
+      url: string;
+      label: string | null;
+      isPrimary: boolean;
+    }>;
+  };
+};

--- a/src/modules/shops/dto/shop-menu.dto.ts
+++ b/src/modules/shops/dto/shop-menu.dto.ts
@@ -1,0 +1,8 @@
+export type ShopMenuDto = {
+  id: string;
+  name: string;
+  price: number | null;
+  priceText: string | null;
+  displayPrice: string | number | null;
+  imageUrl: string | null;
+};

--- a/src/modules/shops/interface/shop-menu.repository.interface.ts
+++ b/src/modules/shops/interface/shop-menu.repository.interface.ts
@@ -1,0 +1,14 @@
+export const SHOP_MENU_REPOSITORY = Symbol('SHOP_MENU_REPOSITORY');
+
+export type ShopMenuRecord = {
+  id: string;
+  name: string;
+  price: number | null;
+  priceText: string | null;
+  imageUrl: string | null;
+  order: number;
+};
+
+export interface IShopMenuRepository {
+  findByShopId(shopId: string): Promise<ShopMenuRecord[]>;
+}

--- a/src/modules/shops/repositories/shop-menu.prisma.repository.ts
+++ b/src/modules/shops/repositories/shop-menu.prisma.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/shared/prisma/prisma.service';
+import type {
+  IShopMenuRepository,
+  ShopMenuRecord,
+} from '../interface/shop-menu.repository.interface';
+
+@Injectable()
+export class ShopMenuPrismaRepository implements IShopMenuRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByShopId(shopId: string): Promise<ShopMenuRecord[]> {
+    return this.prisma.shopMenu.findMany({
+      where: { shopId },
+      select: {
+        id: true,
+        name: true,
+        price: true,
+        priceText: true,
+        imageUrl: true,
+        order: true,
+      },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+    });
+  }
+}

--- a/src/modules/shops/shops.controller.ts
+++ b/src/modules/shops/shops.controller.ts
@@ -30,4 +30,10 @@ export class ShopsController {
     const data = await this.shopsService.getShopHome(shopId);
     return { sucess: true, data };
   }
+
+  @Get(':shopId/menus')
+  async hetShopMenu(@Param('shopId') shopId: string) {
+    const data = await this.shopsService.getShopMenus(shopId);
+    return { success: true, data };
+  }
 }

--- a/src/modules/shops/shops.module.ts
+++ b/src/modules/shops/shops.module.ts
@@ -3,12 +3,15 @@ import { ShopsController } from './shops.controller';
 import { ShopsService } from './shops.service';
 import { SHOPS_REPOSITORY } from './interface/shops.repository.interface';
 import { ShopsPrismaRepository } from './repositories/shops.repository.prisma';
+import { SHOP_MENU_REPOSITORY } from './interface/shop-menu.repository.interface';
+import { ShopMenuPrismaRepository } from './repositories/shop-menu.prisma.repository';
 
 @Module({
   controllers: [ShopsController],
   providers: [
     ShopsService,
     { provide: SHOPS_REPOSITORY, useClass: ShopsPrismaRepository },
+    { provide: SHOP_MENU_REPOSITORY, useClass: ShopMenuPrismaRepository },
   ],
 })
 export class ShopsModule {}

--- a/src/modules/shops/shops.service.ts
+++ b/src/modules/shops/shops.service.ts
@@ -7,32 +7,19 @@ import { GetNearbyShopsQueryDto } from './dto/get-nearby-shops.query.dto';
 import { GetSearchShopsQueryDto } from './dto/get-search-shops.query.dto';
 import { ShopLinkType } from '@prisma/client';
 import { NotFoundException } from '@nestjs/common';
-type ShopHomeDto = {
-  shopId: string;
-  name: string;
-  address: {
-    road: string | null;
-    jibun: string | null;
-  };
-  telephone: string | null;
-  hoursRaw: string | null;
-  links: {
-    website: string | null;
-    instagram: string | null;
-    kakao: string | null;
-    etc: Array<{
-      type: ShopLinkType;
-      url: string;
-      label: string | null;
-      isPrimary: boolean;
-    }>;
-  };
-};
+import { ShopMenuDto } from './dto/shop-menu.dto';
+import { ShopHomeDto } from './dto/shop-home.dto';
+import {
+  type IShopMenuRepository,
+  SHOP_MENU_REPOSITORY,
+} from './interface/shop-menu.repository.interface';
 
 @Injectable()
 export class ShopsService {
   constructor(
     @Inject(SHOPS_REPOSITORY) private readonly shopsRepo: IShopsRepository,
+    @Inject(SHOP_MENU_REPOSITORY)
+    private readonly shopMenuRepo: IShopMenuRepository,
   ) {}
 
   async getAllLocations() {
@@ -109,5 +96,26 @@ export class ShopsService {
         etc,
       },
     };
+  }
+
+  async getShopMenus(shopId: string): Promise<ShopMenuDto[]> {
+    const shop = await this.shopsRepo.findById(shopId);
+    if (!shop) throw new NotFoundException('Shop not found');
+
+    const menus = await this.shopMenuRepo.findByShopId(shopId);
+
+    return menus.map((m) => {
+      const displayPrice =
+        m.price !== null ? m.price : m.priceText !== null ? m.priceText : null;
+
+      return {
+        id: m.id,
+        name: m.name,
+        price: m.price,
+        priceText: m.priceText,
+        displayPrice,
+        imageUrl: m.imageUrl,
+      };
+    });
   }
 }

--- a/test/test.http
+++ b/test/test.http
@@ -47,3 +47,14 @@ Content-Type: application/json
 ### 변수 선언 (파일 맨 아래에 둬도 됨)
 @shopId = cmlj8rdbl0000qou1dde40vu2
 @NOT_EXIST_SHOP_ID = cmlj8rdbl0000qou1dde40vu3
+
+### 메뉴 조회
+GET {{base}}/shops/{{shopId}}/menus
+Accept: application/json
+
+### 존재하지 않는 shop 테스트 (404)
+GET {{base}}/shops/{{NOT_EXIST_SHOP_ID}}/menus
+Accept: application/json
+
+### 변수
+@shopId = 여기에_실제_shop_id_붙여넣기


### PR DESCRIPTION
## 작업 내용
가게 상세 페이지 메뉴 탭에서 필요한 데이터를 조회하는 API를 구현했습니다.

## 주요 기능
- `GET /shops/:shopId/menus` 엔드포인트 추가
- ShopMenu 기반 메뉴 조회 기능 구현
- 가격 정보 가공
  - price가 존재하면 숫자 가격 반환
  - 없을 경우 priceText 반환
  - displayPrice 필드 추가로 프론트 사용성 개선
- 메뉴 정렬 (order 필드 기준)

## 구조
- Repository / Service / Controller 계층 구조 적용
- DTO 기반 응답 구조 설계
- Shop 존재 여부 검증 로직 추가
- 안정적인 정렬을 위한 order + id 기준 정렬 적용

## 기대 효과
- 상세 페이지 메뉴 탭 데이터 로딩 구조 확립
- 프론트에서 별도 가격 처리 로직 없이 displayPrice로 바로 사용 가능

## 다음 작업 예정
- 리뷰 조회 API 구현
- 리뷰 페이징 및 정렬
- 리뷰 이미지 및 키워드 API 설계
- 상세 페이지 성능 및 UX 개선