### PR TITLE
[FEAT] 리뷰 태그 통계 API 구현

### DIFF
--- a/src/modules/reviews/interface/review-tags.repository.interface.ts
+++ b/src/modules/reviews/interface/review-tags.repository.interface.ts
@@ -1,0 +1,18 @@
+import type { Prisma } from '@prisma/client';
+import type { TransactionContext } from 'src/shared/prisma/transaction-runner.interface';
+
+export const REVIEW_TAGS_REPOSITORY = Symbol('REVIEW_TAGS_REPOSITORY');
+
+export type ReviewTagRecord = {
+  id: string;
+  label: string;
+  count: number;
+  externalCount: number | null;
+};
+
+export interface IReviewTagsRepository {
+  findByShopId(
+    shopId: string,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewTagRecord[]>;
+}

--- a/src/modules/reviews/repository/review-tags.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-tags.prisma.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+import { PrismaService } from 'src/shared/prisma/prisma.service';
+import { getDb } from 'src/shared/prisma/get-db';
+import type { TransactionContext } from 'src/shared/prisma/transaction-runner.interface';
+import type {
+  IReviewTagsRepository,
+  ReviewTagRecord,
+} from '../interface/review-tags.repository.interface';
+
+@Injectable()
+export class ReviewTagsPrismaRepository implements IReviewTagsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByShopId(
+    shopId: string,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewTagRecord[]> {
+    const db = getDb(ctx, this.prisma);
+
+    const tags = await db.reviewTag.findMany({
+      where: {
+        shopId,
+        isActive: true,
+      },
+      select: {
+        id: true,
+        label: true,
+        count: true,
+        externalCount: true,
+      },
+    });
+
+    return tags as ReviewTagRecord[];
+  }
+}

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -18,4 +18,10 @@ export class ReviewsController {
       data,
     };
   }
+
+  @Get('shops/:shopId/review-tags')
+  async getShopReviewTags(@Param('shopId') shopId: string) {
+    const data = await this.reviewsService.getShopReviewTags(shopId);
+    return { success: true, data };
+  }
 }

--- a/src/modules/reviews/reviews.module.ts
+++ b/src/modules/reviews/reviews.module.ts
@@ -4,6 +4,8 @@ import { ReviewsService } from './reviews.service';
 import { ReviewsPrismaRepository } from './repository/reviews.prisma.repository';
 import { REVIEWS_REPOSITORY } from './interface/reviews.repository.interface';
 import { ShopsModule } from '../shops/shops.module';
+import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.interface';
+import { ReviewTagsPrismaRepository } from './repository/review-tags.prisma.repository';
 
 @Module({
   imports: [ShopsModule],
@@ -13,6 +15,10 @@ import { ShopsModule } from '../shops/shops.module';
     {
       provide: REVIEWS_REPOSITORY,
       useClass: ReviewsPrismaRepository,
+    },
+    {
+      provide: REVIEW_TAGS_REPOSITORY,
+      useClass: ReviewTagsPrismaRepository,
     },
   ],
 })

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -16,6 +16,8 @@ import {
   type ITransactionRunner,
 } from 'src/shared/prisma/transaction-runner.interface';
 import type { ReviewListItemRecord } from './interface/reviews.repository.interface';
+import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.interface';
+import { type IReviewTagsRepository } from './interface/review-tags.repository.interface';
 
 @Injectable()
 export class ReviewsService {
@@ -28,6 +30,9 @@ export class ReviewsService {
 
     @Inject(TRANSACTION_RUNNER)
     private readonly txRunner: ITransactionRunner<Prisma.TransactionClient>,
+
+    @Inject(REVIEW_TAGS_REPOSITORY)
+    private readonly reviewTagsRepo: IReviewTagsRepository,
   ) {}
 
   async getShopReviews(shopId: string, query: GetShopReviewsQueryDto) {
@@ -88,5 +93,37 @@ export class ReviewsService {
       total,
       hasNext: page * limit < total,
     };
+  }
+
+  // TODO:
+  // 현재는 서비스 초기 단계로 내부 리뷰 데이터가 충분하지 않기 때문에,
+  // 태그 노출 강화를 위해 count + externalCount(displayCount) 기준으로 정렬한다.
+  //
+  // externalCount는 초기 부스팅 및 외부 데이터 연동을 위한 보조 지표이며,
+  // 서비스 안정화 후 제거할 예정이다.
+  //
+  // 이후에는 DB count 기반 정렬로 전환하고,
+  // 정렬 로직을 Service → Repository(DB orderBy)로 이동하여 성능을 개선한다.
+  async getShopReviewTags(shopId: string) {
+    const shop = await this.shopRepo.findById(shopId);
+    if (!shop) throw new NotFoundException('Shop not found');
+
+    const tags = await this.reviewTagsRepo.findByShopId(shopId);
+
+    const mapped = tags.map((t) => {
+      const external = t.externalCount ?? 0;
+
+      return {
+        id: t.id,
+        label: t.label,
+        count: t.count,
+        externalCount: t.externalCount,
+        displayCount: t.count + external,
+      };
+    });
+
+    mapped.sort((a, b) => b.displayCount - a.displayCount);
+
+    return { items: mapped };
   }
 }

--- a/test/test.review.http
+++ b/test/test.review.http
@@ -25,11 +25,6 @@ Accept: application/json
 GET {{baseUrl}}/shops/{{shopId}}/reviews?sort=rating&page=1&limit=10
 Accept: application/json
 
-
-### ===============================
-### Validation / Error Cases
-### ===============================
-
 ### 5) 존재하지 않는 shopId (404 기대)
 GET {{baseUrl}}/shops/NOT_EXIST_SHOP_ID/reviews
 Accept: application/json
@@ -48,3 +43,11 @@ Accept: application/json
 ### 8) sort 잘못된 값 (400 기대)
 GET {{baseUrl}}/shops/{{shopId}}/reviews?sort=hello
 Accept: application/json
+
+### 리뷰 태그 통계 조회
+GET {{baseUrl}}/shops/{{shopId}}/review-tags
+Content-Type: application/json
+
+### 리뷰 태그 통계 조회
+GET {{baseUrl}}/shops/clxxxxx/review-tags
+Content-Type: application/json


### PR DESCRIPTION
## 작업 내용
* 가게 리뷰 태그 통계 조회 API 구현
* ReviewTag Repository 분리 및 인터페이스 구조 적용
* displayCount(count + externalCount) 기반 정렬 로직 구현
* 서비스 초기 데이터 부족 문제를 고려한 태그 노출 전략 적용

## 주요 변경 사항
* 리뷰 태그 조회 기능 추가
* Repository 패턴 기반 구조 개선
* 초기 부스팅(externalCount) 로직 반영
* 서비스 안정화 이후 DB count 기반 정렬로 전환 예정

## TODO (추후 개선 사항)
* [ ] 리뷰 등록 시 태그 count 증가 로직 추가
* [ ] 트랜잭션 기반 태그 업데이트 적용
* [ ] externalCount 제거 및 내부 데이터 기반 통계 전환
* [ ] Repository에서 DB orderBy 처리로 성능 개선
* [ ] Redis 캐싱 적용
* [ ] 태그 추천 및 AI 분석 확장

## 테스트
* 태그 존재 가게 조회 정상 응답 확인
* 태그 없는 가게 조회 시 빈 배열 반환 확인
* 존재하지 않는 가게 404 처리 확인
