### PR TITLE
[FEAT] 가게 사진 하이라이트 API 구현 및 순환 의존성 해결

### DIFF
--- a/src/modules/reviews/interface/review-images.repository.interface.ts
+++ b/src/modules/reviews/interface/review-images.repository.interface.ts
@@ -1,0 +1,19 @@
+import type { Prisma } from '@prisma/client';
+import type { TransactionContext } from 'src/shared/prisma/transaction-runner.interface';
+
+export const REVIEW_IMAGES_REPOSITORY = Symbol('REVIEW_IMAGES_REPOSITORY');
+
+export type ReviewImageListItem = {
+  id: string;
+  url: string;
+  reviewId: string;
+  createdAt: Date;
+};
+
+export interface IReviewImagesRepository {
+  findRecentByShopId(
+    shopId: string,
+    take: number,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewImageListItem[]>;
+}

--- a/src/modules/reviews/repository/review-images.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-images.prisma.repository.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+import { PrismaService } from 'src/shared/prisma/prisma.service';
+import { getDb } from 'src/shared/prisma/get-db';
+import type { TransactionContext } from 'src/shared/prisma/transaction-runner.interface';
+import type {
+  IReviewImagesRepository,
+  ReviewImageListItem,
+} from '../interface/review-images.repository.interface';
+
+@Injectable()
+export class ReviewImagesPrismaRepository implements IReviewImagesRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findRecentByShopId(
+    shopId: string,
+    take: number,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewImageListItem[]> {
+    const db = getDb(ctx, this.prisma);
+
+    return db.reviewImage.findMany({
+      where: { shopId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take,
+      select: { id: true, url: true, reviewId: true, createdAt: true },
+    });
+  }
+}

--- a/src/modules/reviews/reviews.module.ts
+++ b/src/modules/reviews/reviews.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ReviewsController } from './reviews.controller';
 import { ReviewsService } from './reviews.service';
 import { ReviewsPrismaRepository } from './repository/reviews.prisma.repository';
@@ -6,9 +6,11 @@ import { REVIEWS_REPOSITORY } from './interface/reviews.repository.interface';
 import { ShopsModule } from '../shops/shops.module';
 import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.interface';
 import { ReviewTagsPrismaRepository } from './repository/review-tags.prisma.repository';
+import { REVIEW_IMAGES_REPOSITORY } from './interface/review-images.repository.interface';
+import { ReviewImagesPrismaRepository } from './repository/review-images.prisma.repository';
 
 @Module({
-  imports: [ShopsModule],
+  imports: [forwardRef(() => ShopsModule)],
   controllers: [ReviewsController],
   providers: [
     ReviewsService,
@@ -20,6 +22,11 @@ import { ReviewTagsPrismaRepository } from './repository/review-tags.prisma.repo
       provide: REVIEW_TAGS_REPOSITORY,
       useClass: ReviewTagsPrismaRepository,
     },
+    {
+      provide: REVIEW_IMAGES_REPOSITORY,
+      useClass: ReviewImagesPrismaRepository,
+    },
   ],
+  exports: [REVIEW_IMAGES_REPOSITORY],
 })
 export class ReviewsModule {}

--- a/src/modules/shops/shops.controller.ts
+++ b/src/modules/shops/shops.controller.ts
@@ -36,4 +36,23 @@ export class ShopsController {
     const data = await this.shopsService.getShopMenus(shopId);
     return { success: true, data };
   }
+
+  /**
+   * 가게 사진 하이라이트 조회
+   *
+   * 정책:
+   * - heroImageUrl이 존재하면 hero 1장 + 최신 리뷰 이미지 4장
+   * - heroImageUrl이 없으면 최신 리뷰 이미지 5장
+   *
+   * 상단 미리보기 영역(UI) 최적화를 위한 경량 API
+   */
+  @Get(':shopId/photo-highlights')
+  async getPhotoHighlights(@Param('shopId') shopId: string) {
+    const data = await this.shopsService.getPhotoHighlights(shopId);
+
+    return {
+      success: true,
+      data,
+    };
+  }
 }

--- a/src/modules/shops/shops.module.ts
+++ b/src/modules/shops/shops.module.ts
@@ -1,12 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
+import { ReviewsModule } from '../reviews/reviews.module';
+import { SHOP_MENU_REPOSITORY } from './interface/shop-menu.repository.interface';
+import { SHOPS_REPOSITORY } from './interface/shops.repository.interface';
+import { ShopMenuPrismaRepository } from './repositories/shop-menu.prisma.repository';
+import { ShopsPrismaRepository } from './repositories/shops.repository.prisma';
 import { ShopsController } from './shops.controller';
 import { ShopsService } from './shops.service';
-import { SHOPS_REPOSITORY } from './interface/shops.repository.interface';
-import { ShopsPrismaRepository } from './repositories/shops.repository.prisma';
-import { SHOP_MENU_REPOSITORY } from './interface/shop-menu.repository.interface';
-import { ShopMenuPrismaRepository } from './repositories/shop-menu.prisma.repository';
 
 @Module({
+  imports: [forwardRef(() => ReviewsModule)],
   controllers: [ShopsController],
   providers: [
     ShopsService,

--- a/src/modules/shops/shops.service.ts
+++ b/src/modules/shops/shops.service.ts
@@ -13,13 +13,20 @@ import {
   type IShopMenuRepository,
   SHOP_MENU_REPOSITORY,
 } from './interface/shop-menu.repository.interface';
+import {
+  type IReviewImagesRepository,
+  REVIEW_IMAGES_REPOSITORY,
+} from '../reviews/interface/review-images.repository.interface';
 
 @Injectable()
 export class ShopsService {
   constructor(
-    @Inject(SHOPS_REPOSITORY) private readonly shopsRepo: IShopsRepository,
+    @Inject(SHOPS_REPOSITORY)
+    private readonly shopsRepo: IShopsRepository,
     @Inject(SHOP_MENU_REPOSITORY)
     private readonly shopMenuRepo: IShopMenuRepository,
+    @Inject(REVIEW_IMAGES_REPOSITORY)
+    private readonly reviewImagesRepo: IReviewImagesRepository,
   ) {}
 
   async getAllLocations() {
@@ -117,5 +124,30 @@ export class ShopsService {
         imageUrl: m.imageUrl,
       };
     });
+  }
+
+  async getPhotoHighlights(shopId: string) {
+    const shop = await this.shopsRepo.findById(shopId);
+    if (!shop) throw new NotFoundException('Shop not found');
+
+    const heroUrl = shop.heroImageUrl ?? null;
+
+    const need = heroUrl ? 4 : 5;
+
+    const reviewImages = await this.reviewImagesRepo.findRecentByShopId(
+      shopId,
+      need,
+    );
+
+    return {
+      hero: heroUrl ? { url: heroUrl } : null,
+      items: reviewImages.map((img) => ({
+        id: img.id,
+        url: img.url,
+        reviewId: img.reviewId,
+        createdAt: img.createdAt,
+      })),
+      total: (heroUrl ? 1 : 0) + reviewImages.length,
+    };
   }
 }

--- a/test/test.review.http
+++ b/test/test.review.http
@@ -51,3 +51,8 @@ Content-Type: application/json
 ### 리뷰 태그 통계 조회
 GET {{baseUrl}}/shops/clxxxxx/review-tags
 Content-Type: application/json
+
+### 가게 사진 하이라이트 조회 (정상)
+GET {{baseUrl}}/shops/{{shopId}}/photo-highlights
+Content-Type: application/json
+


### PR DESCRIPTION
## 작업 내용
* 가게 사진 하이라이트 조회 API 구현
* hero 이미지 + 리뷰 이미지 기반 상단 미리보기 정책 적용
* ReviewImage Repository 분리
* 모듈 간 순환 의존성 해결(forwardRef 적용)

---

## 구현 상세

### 1. 가게 사진 하이라이트 API
* `GET /shops/:shopId/photo-highlights`
* heroImage + 최신 리뷰 이미지 조합 제공
* 상단 UI 최적화를 위한 경량 응답 구조

정책:
* heroImageUrl이 존재할 경우
  → hero 1장 + 최신 리뷰 이미지 4장
* heroImageUrl이 없을 경우
  → 최신 리뷰 이미지 5장

---

### 2. ReviewImage Repository 분리
* Prisma 직접 접근 제거
* Repository 패턴 적용
* 향후 확장(S3, CDN, 썸네일, AI 분석 등) 대비

---

### 3. 모듈 순환 의존성 해결
사진 기능 구현 과정에서 ShopsModule ↔ ReviewsModule 간 순환 의존성이 발생.

해결:
* NestJS `forwardRef()` 적용
* Module 간 의존성 관계를 명시적으로 처리

적용 위치:
* ShopsModule
* ReviewsModule

---

## 기대 효과
* 사진 관련 로직을 독립적으로 관리 가능
* 리뷰 이미지 기반 기능 확장성 확보
* 구조 개선 및 유지보수성 향상
* 향후 무한스크롤, 캐싱, CDN 적용 준비 완료

---

## 테스트
* hero + 리뷰 이미지 정상 응답 확인
* hero 없는 가게 테스트
* 리뷰 이미지 없는 가게 테스트
* 존재하지 않는 가게 404 확인

---

## TODO
* [ ] 사진 무한스크롤 API 구현
* [ ] cursor 기반 pagination 적용
* [ ] Redis 캐싱 적용
* [ ] 이미지 CDN 연동
* [ ] 이미지 업로드 기능 확장
* [ ] 썸네일 및 최적화 처리
