### PR TITLE
[FEAT] 가게 사진 무한스크롤 API 구현 (Cursor Pagination)

### DIFF
--- a/src/modules/reviews/interface/review-images.repository.interface.ts
+++ b/src/modules/reviews/interface/review-images.repository.interface.ts
@@ -16,4 +16,12 @@ export interface IReviewImagesRepository {
     take: number,
     ctx?: TransactionContext<Prisma.TransactionClient>,
   ): Promise<ReviewImageListItem[]>;
+  findCursorByShopId(
+    shopId: string,
+    args: {
+      take: number;
+      cursorId?: string;
+    },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewImageListItem[]>;
 }

--- a/src/modules/reviews/repository/review-images.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-images.prisma.repository.ts
@@ -26,4 +26,34 @@ export class ReviewImagesPrismaRepository implements IReviewImagesRepository {
       select: { id: true, url: true, reviewId: true, createdAt: true },
     });
   }
+
+  async findCursorByShopId(
+    shopId: string,
+    args: { take: number; cursorId?: string },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewImageListItem[]> {
+    const db = getDb(ctx, this.prisma);
+
+    const takePlusOne = args.take + 1;
+
+    return db.reviewImage.findMany({
+      where: { shopId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: takePlusOne,
+
+      ...(args.cursorId
+        ? {
+            cursor: { id: args.cursorId },
+            skip: 1,
+          }
+        : {}),
+
+      select: {
+        id: true,
+        url: true,
+        reviewId: true,
+        createdAt: true,
+      },
+    });
+  }
 }

--- a/src/modules/shops/dto/get-shop-photos-query.dto.ts
+++ b/src/modules/shops/dto/get-shop-photos-query.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetShopPhotosQueryDto {
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number;
+}

--- a/src/modules/shops/shops.controller.ts
+++ b/src/modules/shops/shops.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ShopsService } from './shops.service';
 import { GetNearbyShopsQueryDto } from './dto/get-nearby-shops.query.dto';
 import { GetSearchShopsQueryDto } from './dto/get-search-shops.query.dto';
-
+import { GetShopPhotosQueryDto } from './dto/get-shop-photos-query.dto';
 @Controller('shops')
 export class ShopsController {
   constructor(private readonly shopsService: ShopsService) {}
@@ -49,6 +49,19 @@ export class ShopsController {
   @Get(':shopId/photo-highlights')
   async getPhotoHighlights(@Param('shopId') shopId: string) {
     const data = await this.shopsService.getPhotoHighlights(shopId);
+
+    return {
+      success: true,
+      data,
+    };
+  }
+
+  @Get(':shopId/photos')
+  async getShopPhotos(
+    @Param('shopId') shopId: string,
+    @Query() query: GetShopPhotosQueryDto,
+  ) {
+    const data = await this.shopsService.getShopPhotos(shopId, query);
 
     return {
       success: true,

--- a/src/modules/shops/shops.service.ts
+++ b/src/modules/shops/shops.service.ts
@@ -17,6 +17,7 @@ import {
   type IReviewImagesRepository,
   REVIEW_IMAGES_REPOSITORY,
 } from '../reviews/interface/review-images.repository.interface';
+import { GetShopPhotosQueryDto } from './dto/get-shop-photos-query.dto';
 
 @Injectable()
 export class ShopsService {
@@ -148,6 +149,42 @@ export class ShopsService {
         createdAt: img.createdAt,
       })),
       total: (heroUrl ? 1 : 0) + reviewImages.length,
+    };
+  }
+
+  async getShopPhotos(shopId: string, query: GetShopPhotosQueryDto) {
+    const shop = await this.shopsRepo.findById(shopId);
+    if (!shop) throw new NotFoundException('Shop not found');
+
+    const limit = query.limit ?? 20;
+    const cursor = query.cursor;
+
+    // 첫 페이지에서만 hero 포함
+    const heroUrl = !cursor ? (shop.heroImageUrl ?? null) : null;
+
+    // hasNext 판정하기 위해 서비스에서 take + 1 로 가져옴
+    const take = limit + 1;
+    const rows = await this.reviewImagesRepo.findCursorByShopId(shopId, {
+      take,
+      cursorId: cursor,
+    });
+
+    const hasNext = rows.length > limit;
+    const items = hasNext ? rows.slice(0, limit) : rows;
+
+    const lastItem = items[items.length - 1];
+    const nextCursor = hasNext && lastItem ? lastItem.id : null;
+
+    return {
+      hero: heroUrl ? { url: heroUrl } : null,
+      items: items.map((img) => ({
+        id: img.id,
+        url: img.url,
+        reviewId: img.reviewId,
+        createdAt: img.createdAt,
+      })),
+      nextCursor,
+      hasNext,
     };
   }
 }

--- a/test/test.review.http
+++ b/test/test.review.http
@@ -56,3 +56,10 @@ Content-Type: application/json
 GET {{baseUrl}}/shops/{{shopId}}/photo-highlights
 Content-Type: application/json
 
+### 존재하지 않는 가게
+GET {{baseUrl}}/shops/not-exist/photo-highlights
+Content-Type: application/json
+
+### 가게 사진 첫 페이지 (hero + review images)
+GET {{baseUrl}}/shops/{{shopId}}/photos
+Content-Type: application/json


### PR DESCRIPTION
## 작업 내용
* 가게 사진 무한스크롤 조회 API 구현 (cursor pagination)
* 첫 페이지에서만 hero 이미지 포함 정책 적용
* ReviewImage cursor 조회용 Repository 메서드 추가

---

## 구현 상세

### 1. 가게 사진 무한스크롤 API
* `GET /shops/:shopId/photos`
* Query: `cursor?: string`, `limit?: number` (default 20, max 50)
* 응답: `items`, `nextCursor`, `hasNext` (+ 첫 페이지일 때만 `hero`)

정책:
* 첫 페이지(cursor 없음)
  → `hero` 포함 + 리뷰 이미지 cursor 기반으로 내려줌
* 다음 페이지(cursor 있음)
  → `hero: null` (중복 노출 방지) + 다음 리뷰 이미지 페이지 제공

Pagination 전략:
* 서비스에서 `take = limit + 1`로 조회하여 `hasNext` 판정
* `nextCursor`는 응답 `items`의 마지막 `id`

---
### 2. ReviewImage Repository 확장
* cursor 기반 조회를 위한 메서드 추가
  * `findCursorByShopId(shopId, { take, cursorId })`
* 정렬: `createdAt desc`, `id desc`
* cursor가 있을 때 `skip: 1`로 cursor 항목 중복 방지

---

## 기대 효과
* 사진 탭(갤러리)에서 무한스크롤 UX 구현 가능
* cursor 기반으로 중복/누락 가능성 감소 및 성능 확보
* 이후 캐싱/정렬/필터 확장에 유리한 API 형태

---

## 테스트
* 첫 페이지: hero 포함 여부 확인, limit 적용 확인
* 다음 페이지: hero 미포함 확인, nextCursor 이어 조회 확인
* 마지막 페이지: `hasNext=false`, `nextCursor=null` 확인
* 존재하지 않는 shopId: 404 확인

---

## TODO
* [ ] 사진 정렬 옵션 확장(인기/추천 등)
* [ ] Redis 캐싱 검토
* [ ] 이미지 CDN 연동 및 썸네일 최적화
* [ ] 갤러리 응답에 필요한 메타(총 개수 등) 제공 여부 검토
