### PR TITLE
[FIX] 로컬 PostGIS 환경을 Supabase PostGIS 환경에 맞게 마이그레이션 및 거리 검색 쿼리 수정

### DIFF
--- a/prisma/migrations/20260215083509_add_shop_geo/migration.sql
+++ b/prisma/migrations/20260215083509_add_shop_geo/migration.sql
@@ -1,19 +1,38 @@
-CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA extensions;
 
 -- AlterTable
 ALTER TABLE "Shop"
-ADD COLUMN "geo" public.geography(Point, 4326);
+ADD COLUMN "geo" extensions.geography(Point, 4326);
 
 UPDATE "Shop"
-SET "geo" = public.ST_SetSRID(
-  public.ST_MakePoint(
+SET "geo" = extensions.ST_SetSRID(
+  extensions.ST_MakePoint(
     CAST("longitude" AS double precision),
     CAST("latitude"  AS double precision)
   ),
   4326
-)::public.geography
+)::extensions.geography
 WHERE "geo" IS NULL;
 
 CREATE INDEX IF NOT EXISTS "Shop_geo_gix"
 ON "Shop"
 USING GIST ("geo");
+-- CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+
+-- -- AlterTable
+-- ALTER TABLE "Shop"
+-- ADD COLUMN "geo" public.geography(Point, 4326);
+
+-- UPDATE "Shop"
+-- SET "geo" = public.ST_SetSRID(
+--   public.ST_MakePoint(
+--     CAST("longitude" AS double precision),
+--     CAST("latitude"  AS double precision)
+--   ),
+--   4326
+-- )::public.geography
+-- WHERE "geo" IS NULL;
+
+-- CREATE INDEX IF NOT EXISTS "Shop_geo_gix"
+-- ON "Shop"
+-- USING GIST ("geo");

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
     origin: ['http://localhost:3000'],
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: false,
+    credentials: true,
   });
 
   const port = process.env.PORT ?? 4000;

--- a/src/modules/shops/repositories/shops.repository.prisma.ts
+++ b/src/modules/shops/repositories/shops.repository.prisma.ts
@@ -103,14 +103,14 @@ export class ShopsPrismaRepository implements IShopsRepository {
 
       WHERE s."isActive" = true
         AND s."geo" IS NOT NULL
-        AND public.ST_DWithin(
+        AND extensions.ST_DWithin(
           s."geo",
-          public.ST_SetSRID(public.ST_MakePoint(${lng}, ${lat}), 4326)::public.geography,
+          extensions.ST_SetSRID(extensions.ST_MakePoint(${lng}, ${lat}), 4326)::extensions.geography,
           ${radiusKm} * 1000
         )
-      ORDER BY public.ST_Distance(
+      ORDER BY extensions.ST_Distance(
         s."geo",
-        public.ST_SetSRID(public.ST_MakePoint(${lng}, ${lat}), 4326)::public.geography
+        extensions.ST_SetSRID(extensions.ST_MakePoint(${lng}, ${lat}), 4326)::extensions.geography
       ) ASC
       LIMIT ${limit}
       OFFSET ${offset};
@@ -134,7 +134,7 @@ export class ShopsPrismaRepository implements IShopsRepository {
     const search = (params.search ?? '').trim();
 
     const point = Prisma.sql`
-      public.ST_SetSRID(public.ST_MakePoint(${lng}, ${lat}), 4326)::public.geography
+      extensions.ST_SetSRID(extensions.ST_MakePoint(${lng}, ${lat}), 4326)::extensions.geography
     `;
 
     // search가 있을 때만 WHERE 조건을 추가
@@ -195,13 +195,13 @@ export class ShopsPrismaRepository implements IShopsRepository {
   
         WHERE s."isActive" = true
           AND s."geo" IS NOT NULL
-          AND public.ST_DWithin(
+          AND extensions.ST_DWithin(
             s."geo",
             ${point},
             ${radiusKm} * 1000
           )
           ${searchWhere}
-        ORDER BY public.ST_Distance(s."geo", ${point}) ASC
+        ORDER BY extensions.ST_Distance(s."geo", ${point}) ASC
         LIMIT ${limit}
         OFFSET ${offset};
       `,


### PR DESCRIPTION
## 작업 배경
기존에는 로컬 PostgreSQL + PostGIS 환경에서 개발을 진행했다.  
로컬 환경에서는 PostGIS extension을 `public` 스키마 기준으로 사용하고 있었고,
거리 검색 및 geo 컬럼 관련 SQL도 모두 `public.ST_*`, `public.geography` 기준으로 작성되어 있었다.

이번 작업에서는 데이터베이스를 Supabase Postgres로 이전하면서
기존 로컬 DB 구조를 Prisma migration을 통해 Supabase DB에 반영했다.

## 문제 상황
Supabase에서 PostGIS extension을 활성화한 뒤 migration을 적용하는 과정에서
기존 migration SQL이 `public.geography` 타입을 참조하고 있어 에러가 발생했다.

또한 migration을 수정해 적용한 이후에도,
런타임에서 거리 검색 raw query가 여전히 `public.ST_*`, `public.geography`를 사용하고 있어
다음 에러가 발생했다.

- `type "public.geography" does not exist`

확인 결과 Supabase 환경에서는 PostGIS extension이 `public`이 아니라 `extensions` 스키마에 설치되어 있었다.

## 작업 내용

### 1. Supabase DB 연결 구성
- 기존 로컬 DB 대신 Supabase Postgres를 사용하도록 환경변수 변경
- Prisma migration이 Supabase DB에 적용되도록 DB 연결 구성 정리

### 2. PostGIS extension 스키마 확인
- Supabase SQL Editor에서 `pg_extension` 조회
- PostGIS extension이 `public`이 아닌 `extensions` 스키마에 설치된 것을 확인

### 3. Prisma migration 수정
기존 migration에서 아래와 같이 `public` 스키마를 참조하던 부분을 수정했다.

변경 전
- `CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;`
- `public.geography(Point, 4326)`
- `public.ST_SetSRID(...)`
- `public.ST_MakePoint(...)`

변경 후
- `CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA extensions;`
- `extensions.geography(Point, 4326)`
- `extensions.ST_SetSRID(...)`
- `extensions.ST_MakePoint(...)`

이를 통해 `Shop.geo` 컬럼 생성 및 공간 인덱스 생성 migration이
Supabase 환경에서도 정상 적용되도록 수정했다.

### 4. 실패한 migration 복구 및 재적용
- 실패 상태로 남아 있던 migration을 rolled back 처리
- 수정된 migration을 다시 deploy하여 Supabase DB에 정상 반영

### 5. 런타임 거리 검색 쿼리 수정
`ShopsPrismaRepository`의 raw query에서 PostGIS 함수를 `public` 기준으로 호출하던 부분을
Supabase 환경에 맞게 `extensions` 기준으로 수정했다.

변경 대상
- `public.ST_DWithin` → `extensions.ST_DWithin`
- `public.ST_Distance` → `extensions.ST_Distance`
- `public.ST_SetSRID` → `extensions.ST_SetSRID`
- `public.ST_MakePoint` → `extensions.ST_MakePoint`
- `::public.geography` → `::extensions.geography`

수정 범위
- `findNearby()`
- `search()`

## 결과
- Supabase DB에 Prisma migration 정상 적용
- `Shop.geo` geography 컬럼 및 공간 인덱스 정상 생성
- 서버 실행 시 PostGIS 관련 런타임 에러 해소
- 거리 기반 검색 API가 Supabase 환경에서도 정상 동작하도록 수정