### PR TITLE
feat: OAuth 로그인 구조를 one-time code 교환 방식으로 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
         "cookie-parser": "^1.4.7",
+        "ioredis": "^5.10.0",
         "ms": "^2.1.3",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -1442,6 +1443,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -4910,6 +4917,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5284,7 +5300,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -6757,6 +6772,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.0.tgz",
+      "integrity": "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7981,10 +8020,22 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -9526,6 +9577,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -10000,6 +10072,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
     "cookie-parser": "^1.4.7",
+    "ioredis": "^5.10.0",
     "ms": "^2.1.3",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,6 +7,8 @@ import {
   Body,
   UnauthorizedException,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -84,6 +86,7 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @HttpCode(HttpStatus.OK)
   async refresh(@Req() req: Request, @Res() res: Response) {
     const refreshToken = req.cookies?.['refresh_token'] as string | undefined;
     if (!refreshToken) {
@@ -98,10 +101,17 @@ export class AuthController {
 
     this.setRefreshCookie(res, newRefreshToken);
 
-    return res.json({ accessToken, sessionId });
+    return res.json({
+      success: true,
+      data: {
+        accessToken,
+        sessionId,
+      },
+    });
   }
 
   @Post('exchange')
+  @HttpCode(HttpStatus.OK)
   async exchange(
     @Body('code') code: string,
     @Req() req: Request,
@@ -126,12 +136,16 @@ export class AuthController {
     this.setRefreshCookie(res, refreshToken);
 
     return res.json({
-      accessToken,
-      sessionId,
+      success: true,
+      data: {
+        accessToken,
+        sessionId,
+      },
     });
   }
 
   @Post('logout')
+  @HttpCode(HttpStatus.OK)
   async logout(@Req() req: Request, @Res() res: Response) {
     const refreshToken = req.cookies?.['refresh_token'] as string | undefined;
 
@@ -154,6 +168,11 @@ export class AuthController {
       sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
     });
 
-    return res.json({ ok: true });
+    return res.json({
+      success: true,
+      data: {
+        ok: true,
+      },
+    });
   }
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -4,16 +4,23 @@ import {
   Post,
   Req,
   Res,
+  Body,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
+import { OAuthCodeService } from './oauth.code.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+    private readonly oauthCodeService: OAuthCodeService,
+  ) {}
 
   private setRefreshCookie(res: Response, refreshToken: string) {
     res.cookie('refresh_token', refreshToken, {
@@ -24,7 +31,28 @@ export class AuthController {
     });
   }
 
-  // GOOGLE
+  private async handleOAuthCallback(req: Request, res: Response) {
+    const oauthUser = req.user as { userId?: string } | undefined;
+
+    if (!oauthUser?.userId) {
+      throw new UnauthorizedException('OAuth user missing');
+    }
+
+    const code = await this.oauthCodeService.createCode({
+      userId: oauthUser.userId,
+    });
+
+    const frontendUrl = this.configService.get<string>('FRONTEND_URL');
+    if (!frontendUrl) {
+      throw new UnauthorizedException('FRONTEND_URL missing');
+    }
+
+    const redirectUrl = new URL('/oauth/callback', frontendUrl);
+    redirectUrl.searchParams.set('code', code);
+
+    return res.redirect(redirectUrl.toString());
+  }
+
   @Get('google')
   @UseGuards(AuthGuard('google'))
   googleLogin() {}
@@ -32,23 +60,9 @@ export class AuthController {
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
   async googleCallback(@Req() req: Request, @Res() res: Response) {
-    const oauthUser = req.user;
-    if (!oauthUser?.userId) {
-      throw new UnauthorizedException('OAuth user missing');
-    }
-
-    const { accessToken, refreshToken, sessionId } =
-      await this.authService.issueTokens(oauthUser.userId, {
-        userAgent: req.headers['user-agent'] ?? '',
-        ip: req.ip,
-      });
-
-    this.setRefreshCookie(res, refreshToken);
-
-    return res.json({ accessToken, sessionId });
+    return this.handleOAuthCallback(req, res);
   }
 
-  // KAKAO
   @Get('kakao')
   @UseGuards(AuthGuard('kakao'))
   kakaoLogin() {}
@@ -56,24 +70,9 @@ export class AuthController {
   @Get('kakao/callback')
   @UseGuards(AuthGuard('kakao'))
   async kakaoCallback(@Req() req: Request, @Res() res: Response) {
-    const oauthUser = req.user;
-
-    if (!oauthUser?.userId) {
-      throw new UnauthorizedException('OAuth user missing');
-    }
-
-    const { accessToken, refreshToken, sessionId } =
-      await this.authService.issueTokens(oauthUser.userId, {
-        userAgent: req.headers['user-agent'] ?? '',
-        ip: req.ip,
-      });
-
-    this.setRefreshCookie(res, refreshToken);
-
-    return res.json({ accessToken, sessionId });
+    return this.handleOAuthCallback(req, res);
   }
 
-  // NAVER
   @Get('naver')
   @UseGuards(AuthGuard('naver'))
   naverLogin() {}
@@ -81,21 +80,7 @@ export class AuthController {
   @Get('naver/callback')
   @UseGuards(AuthGuard('naver'))
   async naverCallback(@Req() req: Request, @Res() res: Response) {
-    const oauthUser = req.user;
-
-    if (!oauthUser?.userId) {
-      throw new UnauthorizedException('OAuth user missing');
-    }
-
-    const { accessToken, refreshToken, sessionId } =
-      await this.authService.issueTokens(oauthUser.userId, {
-        userAgent: req.headers['user-agent'] ?? '',
-        ip: req.ip,
-      });
-
-    this.setRefreshCookie(res, refreshToken);
-
-    return res.json({ accessToken, sessionId });
+    return this.handleOAuthCallback(req, res);
   }
 
   @Post('refresh')
@@ -116,6 +101,36 @@ export class AuthController {
     return res.json({ accessToken, sessionId });
   }
 
+  @Post('exchange')
+  async exchange(
+    @Body('code') code: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    if (!code) {
+      throw new UnauthorizedException('No exchange code');
+    }
+
+    const payload = await this.oauthCodeService.consumeCode(code);
+
+    if (!payload?.userId) {
+      throw new UnauthorizedException('Invalid or expired exchange code');
+    }
+
+    const { accessToken, refreshToken, sessionId } =
+      await this.authService.issueTokens(payload.userId, {
+        userAgent: req.headers['user-agent'] ?? '',
+        ip: req.ip,
+      });
+
+    this.setRefreshCookie(res, refreshToken);
+
+    return res.json({
+      accessToken,
+      sessionId,
+    });
+  }
+
   @Post('logout')
   async logout(@Req() req: Request, @Res() res: Response) {
     const refreshToken = req.cookies?.['refresh_token'] as string | undefined;
@@ -128,11 +143,16 @@ export class AuthController {
           await this.authService.logout(payload.sid);
         }
       } catch {
-        // 토큰이 이미 만료되었거나 변조된 경우도 logout은 성공 처리
+        // 만료/변조되어도 로그아웃은 성공 처리
       }
     }
 
-    res.clearCookie('refresh_token', { path: '/auth/refresh' });
+    res.clearCookie('refresh_token', {
+      path: '/auth/refresh',
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+    });
 
     return res.json({ ok: true });
   }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,6 +9,8 @@ import { SESSION_REPOSITORY } from './interface/session.repository.interface';
 import { AuthController } from './auth.controller';
 import { KakaoStrategy } from './strategies/kakao.strategy';
 import { NaverStrategy } from './strategies/naver.strategy';
+import { RedisProvider } from 'src/shared/redis/redis.provider';
+import { OAuthCodeService } from './oauth.code.service';
 
 @Module({
   imports: [ConfigModule, JwtModule.register({}), UsersModule],
@@ -19,6 +21,8 @@ import { NaverStrategy } from './strategies/naver.strategy';
     KakaoStrategy,
     NaverStrategy,
     SessionPrismaRepository,
+    OAuthCodeService,
+    RedisProvider,
     {
       provide: SESSION_REPOSITORY,
       useExisting: SessionPrismaRepository,

--- a/src/modules/auth/oauth.code.service.ts
+++ b/src/modules/auth/oauth.code.service.ts
@@ -1,0 +1,83 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+type CreateCodeParams = {
+  userId: string;
+};
+
+type OAuthCodePayload = {
+  userId: string;
+};
+
+@Injectable()
+export class OAuthCodeService {
+  private readonly keyPrefix = 'oauth:code:';
+  private readonly ttlSeconds = 60; // 1분
+
+  constructor(
+    @Inject('REDIS_CLIENT')
+    private readonly redis: {
+      set: (
+        key: string,
+        value: string,
+        mode: 'EX',
+        duration: number,
+      ) => Promise<unknown>;
+      get: (key: string) => Promise<string | null>;
+      del: (key: string) => Promise<number>;
+    },
+  ) {}
+
+  private buildKey(code: string) {
+    return `${this.keyPrefix}${code}`;
+  }
+
+  async createCode({ userId }: CreateCodeParams): Promise<string> {
+    const code = randomUUID();
+
+    const payload: OAuthCodePayload = {
+      userId,
+    };
+
+    await this.redis.set(
+      this.buildKey(code),
+      JSON.stringify(payload),
+      'EX',
+      this.ttlSeconds,
+    );
+
+    return code;
+  }
+
+  /**
+   * TODO:
+   * 현재 구현은 Redis에서 GET 후 DEL을 수행하는 방식이다.
+   * 이 방식은 완전한 원자적(atomic) 처리가 아니기 때문에
+   * 매우 드물지만 동시에 두 요청이 들어올 경우 race condition 가능성이 있다.
+   *
+   * 로컬 개발 및 초기 서비스 단계에서는 충분히 동작하지만,
+   * 추후 보안 및 동시성 안정성을 위해 아래 방식으로 개선할 수 있다.
+   *
+   * 1. Redis GETDEL 명령어 사용
+   * 2. Lua Script로 get+delete 원자 처리
+   * 3. Redis transaction (MULTI / EXEC)
+   *
+   * 현재는 구현 단순성을 위해 GET → DEL 방식으로 유지한다.
+   */
+  async consumeCode(code: string): Promise<OAuthCodePayload | null> {
+    const key = this.buildKey(code);
+
+    const raw = await this.redis.get(key);
+    if (!raw) {
+      return null;
+    }
+
+    await this.redis.del(key);
+
+    try {
+      return JSON.parse(raw) as OAuthCodePayload;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/modules/shops/dto/get-search-shops.query.dto.ts
+++ b/src/modules/shops/dto/get-search-shops.query.dto.ts
@@ -23,7 +23,7 @@ export class GetSearchShopsQueryDto {
   @IsNumber()
   @Min(0.1)
   @Max(50)
-  radiusKm?: number = 3;
+  radiusKm?: number = 50;
 
   @IsOptional()
   @Type(() => Number)

--- a/src/modules/shops/shops.controller.ts
+++ b/src/modules/shops/shops.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Header, Param, Query } from '@nestjs/common';
 import { ShopsService } from './shops.service';
 import { GetNearbyShopsQueryDto } from './dto/get-nearby-shops.query.dto';
 import { GetSearchShopsQueryDto } from './dto/get-search-shops.query.dto';
@@ -13,6 +13,7 @@ export class ShopsController {
     return { success: true, data };
   }
 
+  @Header('Cache-Control', 'no-store')
   @Get('search')
   async searchShops(@Query() query: GetSearchShopsQueryDto) {
     const data = await this.shopsService.searchShops(query);
@@ -28,7 +29,7 @@ export class ShopsController {
   @Get(':shopId/home')
   async getShopHome(@Param('shopId') shopId: string) {
     const data = await this.shopsService.getShopHome(shopId);
-    return { sucess: true, data };
+    return { success: true, data };
   }
 
   @Get(':shopId/menus')

--- a/src/shared/redis/redis.provider.ts
+++ b/src/shared/redis/redis.provider.ts
@@ -1,0 +1,12 @@
+import Redis from 'ioredis';
+
+export const RedisProvider = {
+  provide: 'REDIS_CLIENT',
+  useFactory: () => {
+    return new Redis({
+      host: process.env.REDIS_HOST ?? 'localhost',
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      password: process.env.REDIS_PASSWORD ?? undefined,
+    });
+  },
+};

--- a/test/test.http
+++ b/test/test.http
@@ -56,5 +56,3 @@ Accept: application/json
 GET {{base}}/shops/{{NOT_EXIST_SHOP_ID}}/menus
 Accept: application/json
 
-### 변수
-@shopId = 여기에_실제_shop_id_붙여넣기


### PR DESCRIPTION
## 배경
기존 OAuth 로그인 구조에서는 callback 단계에서 accessToken을 JSON 응답으로 반환하고 있었습니다.

이 구조에서는 다음과 같은 문제가 있었습니다.

1. OAuth 로그인 후 프론트 화면으로 자연스럽게 이동하기 어려움
2. UI 흐름이 끊기고 사용자가 직접 페이지 이동을 처리해야 함
3. OAuth 특성상 redirect 기반 로그인 흐름과 맞지 않음

따라서 OAuth 인증 이후 프론트 페이지로 redirect되는 구조로 변경하고자 했습니다.

---

## 문제

redirect를 사용하는 경우 accessToken을 URL query로 전달해야 하는 상황이 발생합니다.

예시:

/oauth/callback?accessToken=...

하지만 이 방식은 다음과 같은 보안 문제가 있습니다.

- accessToken이 브라우저 URL에 노출
- 브라우저 히스토리에 저장
- 로그 / 리퍼러 등에 남을 가능성 존재

따라서 accessToken을 URL에 직접 전달하는 방식은 적절하지 않다고 판단했습니다.

---

## 해결 방법

OAuth callback에서는 accessToken을 바로 발급하지 않고  
one-time code를 생성하여 프론트로 전달하는 방식으로 변경했습니다.

새로운 로그인 흐름은 다음과 같습니다.

OAuth 로그인
↓
/auth/{provider}/callback
↓
one-time code 생성 (Redis)
↓
redirect → /oauth/callback?code=xxxx
↓
프론트가 /auth/exchange 호출
↓
accessToken / refreshToken 발급

이 구조를 통해 다음을 달성할 수 있습니다.

- redirect 기반 OAuth 로그인 UX 구현
- accessToken URL 노출 방지
- 웹 / 앱 공통 로그인 구조 확장 가능

---

## 주요 변경 사항

- OAuth callback에서 accessToken 직접 발급 제거
- one-time code 기반 로그인 방식 도입
- `/auth/exchange` API 추가
- `OAuthCodeService` 추가 (code 생성 및 관리)
- refreshToken cookie 세팅을 exchange 단계로 이동

---

## 기대 효과

- OAuth 로그인 UX 개선
- accessToken URL 노출 제거
- 보안 개선
- 모바일 앱 OAuth 로그인 구조와 호환 가능

---

## TODO

- Redis 기반 OAuthCodeService 실제 연동
- consumeCode atomic 처리 개선 (Redis GETDEL / Lua script)