### PR TITLE
[FIX] Prisma generate 누락으로 인한 빌드 실패 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "build": "nest build",
+    "build": "prisma generate && nest build",
+    "postinstall": "prisma generate",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
## 📌 배경

Railway 배포 과정에서 build 단계에서 에러가 발생하며 배포가 실패했습니다.

로그 확인 결과 다음과 같은 에러가 발생했습니다:

- `Module '"@prisma/client"' has no exported member 'PrismaClient'`
- `Property '$disconnect' does not exist`
- 총 41개의 타입 에러 발생

---

## 문제 원인
Prisma Client는 `prisma generate`를 통해 생성되는데, 현재 프로젝트에서는 build 이전에 해당 명령이 실행되지 않아 `@prisma/client` 내부 타입 및 모델들이 생성되지 않은 상태였습니다.

이로 인해:
- PrismaClient
- enum (ShopLinkType, DessertCategory 등)
- model (User, Shop 등)

이 모두 undefined 상태가 되어 TypeScript 에러가 발생했습니다.

---

## 해결 방법

build 이전에 Prisma Client를 생성하도록 설정을 추가했습니다.

### 변경 사항

```json
{
  "scripts": {
    "build": "prisma generate && nest build",
    "postinstall": "prisma generate"
  }
}
```