### PR TITLE
[FEAT] 리뷰 등록 API 및 인증 가드 적용

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -11,6 +11,7 @@ import { KakaoStrategy } from './strategies/kakao.strategy';
 import { NaverStrategy } from './strategies/naver.strategy';
 import { RedisProvider } from 'src/shared/redis/redis.provider';
 import { OAuthCodeService } from './oauth.code.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Module({
   imports: [ConfigModule, JwtModule.register({}), UsersModule],
@@ -27,7 +28,8 @@ import { OAuthCodeService } from './oauth.code.service';
       provide: SESSION_REPOSITORY,
       useExisting: SessionPrismaRepository,
     },
+    JwtAuthGuard,
   ],
-  exports: [AuthService],
+  exports: [AuthService, JwtAuthGuard, JwtModule],
 })
 export class AuthModule {}

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,65 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { Request } from 'express';
+import type { AuthPrincipal } from '../types/auth-pricncipal';
+
+type AccessPayload = {
+  sub: string;
+};
+
+type AuthenticatedRequest = Request & {
+  user?: AuthPrincipal;
+};
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const token = this.extractAccessToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Access token이 없습니다.');
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync<AccessPayload>(token, {
+        secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
+      });
+
+      request.user = {
+        userId: payload.sub,
+      };
+
+      return true;
+    } catch {
+      throw new UnauthorizedException('유효하지 않은 access token입니다.');
+    }
+  }
+
+  private extractAccessToken(request: Request): string | null {
+    const authorization = request.headers.authorization;
+
+    if (!authorization) {
+      return null;
+    }
+
+    const [type, token] = authorization.split(' ');
+
+    if (type !== 'Bearer' || !token) {
+      return null;
+    }
+
+    return token;
+  }
+}

--- a/src/modules/reviews/dto/create-review-dto.ts
+++ b/src/modules/reviews/dto/create-review-dto.ts
@@ -1,0 +1,29 @@
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  IsArray,
+  ArrayMaxSize,
+  IsUrl,
+} from 'class-validator';
+
+export class CreateReviewDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating: number;
+
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10) // 최대 10장 제한
+  @IsUrl({}, { each: true })
+  imageUrls?: string[];
+}

--- a/src/modules/reviews/interface/review-images.repository.interface.ts
+++ b/src/modules/reviews/interface/review-images.repository.interface.ts
@@ -11,6 +11,16 @@ export type ReviewImageListItem = {
 };
 
 export interface IReviewImagesRepository {
+  createMany(
+    data: Array<{
+      shopId: string;
+      reviewId: string;
+      uploaderId: string;
+      url: string;
+      order: number;
+    }>,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<void>;
   findRecentByShopId(
     shopId: string,
     take: number,

--- a/src/modules/reviews/interface/reviews.repository.interface.ts
+++ b/src/modules/reviews/interface/reviews.repository.interface.ts
@@ -30,7 +30,44 @@ export type ReviewListItemRecord = Prisma.ReviewGetPayload<{
   };
 }>;
 
+export type ReviewDetailRecord = Prisma.ReviewGetPayload<{
+  select: {
+    id: true;
+    rating: true;
+    content: true;
+    createdAt: true;
+    updatedAt: true;
+    author: {
+      select: {
+        id: true;
+        nickname: true;
+        profileImageUrl: true;
+      };
+    };
+    images: {
+      select: {
+        id: true;
+        url: true;
+        order: true;
+      };
+    };
+  };
+}>;
+
 export interface IReviewsRepository {
+  create(
+    data: {
+      shopId: string;
+      authorId: string;
+      rating: number;
+      content: string | null;
+    },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<{ id: string }>;
+  findById(
+    reviewId: string,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewDetailRecord | null>;
   countByShopId(
     shopId: string,
     ctx?: TransactionContext<Prisma.TransactionClient>,

--- a/src/modules/reviews/repository/review-images.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-images.prisma.repository.ts
@@ -11,6 +11,22 @@ import type {
 @Injectable()
 export class ReviewImagesPrismaRepository implements IReviewImagesRepository {
   constructor(private readonly prisma: PrismaService) {}
+  async createMany(
+    data: Array<{
+      shopId: string;
+      reviewId: string;
+      uploaderId: string;
+      url: string;
+      order: number;
+    }>,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<void> {
+    const db = getDb(ctx, this.prisma);
+
+    await db.reviewImage.createMany({
+      data,
+    });
+  }
 
   async findRecentByShopId(
     shopId: string,

--- a/src/modules/reviews/repository/reviews.prisma.repository.ts
+++ b/src/modules/reviews/repository/reviews.prisma.repository.ts
@@ -1,4 +1,3 @@
-// src/modules/reviews/repository/reviews.repository.ts
 import { Injectable } from '@nestjs/common';
 import type { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/shared/prisma/prisma.service';
@@ -9,11 +8,66 @@ import type {
   ReviewOrderBy,
   ReviewListItemRecord,
 } from '../interface/reviews.repository.interface';
+import { ReviewDetailRecord } from '../interface/reviews.repository.interface';
 
 @Injectable()
 export class ReviewsPrismaRepository implements IReviewsRepository {
   constructor(private readonly prisma: PrismaService) {}
+  async create(
+    data: {
+      shopId: string;
+      authorId: string;
+      rating: number;
+      content: string | null;
+    },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<{ id: string }> {
+    const db = getDb(ctx, this.prisma);
 
+    const review = await db.review.create({
+      data,
+      select: {
+        id: true,
+      },
+    });
+
+    return review;
+  }
+
+  async findById(
+    reviewId: string,
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<ReviewDetailRecord | null> {
+    const db = getDb(ctx, this.prisma);
+
+    return db.review.findUnique({
+      where: {
+        id: reviewId,
+      },
+      select: {
+        id: true,
+        rating: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+        author: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImageUrl: true,
+          },
+        },
+        images: {
+          select: {
+            id: true,
+            url: true,
+            order: true,
+          },
+          orderBy: [{ order: 'asc' }, { id: 'asc' }],
+        },
+      },
+    });
+  }
   async countByShopId(
     shopId: string,
     ctx?: TransactionContext<Prisma.TransactionClient>,

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -1,6 +1,17 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Req,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { GetShopReviewsQueryDto } from './dto/get-shop-reviews-query-dto';
+import { CreateReviewDto } from './dto/create-review-dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller()
 export class ReviewsController {
@@ -23,5 +34,24 @@ export class ReviewsController {
   async getShopReviewTags(@Param('shopId') shopId: string) {
     const data = await this.reviewsService.getShopReviewTags(shopId);
     return { success: true, data };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('shops/:shopId/reviews')
+  async createReview(
+    @Param('shopId') shopId: string,
+    @Body() body: CreateReviewDto,
+    @Req() req: { user: { userId: string } },
+  ) {
+    const data = await this.reviewsService.createReview(
+      shopId,
+      req.user.userId,
+      body,
+    );
+
+    return {
+      success: true,
+      data,
+    };
   }
 }

--- a/src/modules/reviews/reviews.module.ts
+++ b/src/modules/reviews/reviews.module.ts
@@ -8,9 +8,10 @@ import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.inter
 import { ReviewTagsPrismaRepository } from './repository/review-tags.prisma.repository';
 import { REVIEW_IMAGES_REPOSITORY } from './interface/review-images.repository.interface';
 import { ReviewImagesPrismaRepository } from './repository/review-images.prisma.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [forwardRef(() => ShopsModule)],
+  imports: [forwardRef(() => ShopsModule), AuthModule],
   controllers: [ReviewsController],
   providers: [
     ReviewsService,

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -18,6 +18,11 @@ import {
 import type { ReviewListItemRecord } from './interface/reviews.repository.interface';
 import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.interface';
 import { type IReviewTagsRepository } from './interface/review-tags.repository.interface';
+import { CreateReviewDto } from './dto/create-review-dto';
+import {
+  type IReviewImagesRepository,
+  REVIEW_IMAGES_REPOSITORY,
+} from './interface/review-images.repository.interface';
 
 @Injectable()
 export class ReviewsService {
@@ -33,6 +38,9 @@ export class ReviewsService {
 
     @Inject(REVIEW_TAGS_REPOSITORY)
     private readonly reviewTagsRepo: IReviewTagsRepository,
+
+    @Inject(REVIEW_IMAGES_REPOSITORY)
+    private readonly reviewImagesRepo: IReviewImagesRepository,
   ) {}
 
   async getShopReviews(shopId: string, query: GetShopReviewsQueryDto) {
@@ -125,5 +133,67 @@ export class ReviewsService {
     mapped.sort((a, b) => b.displayCount - a.displayCount);
 
     return { items: mapped };
+  }
+
+  async createReview(shopId: string, userId: string, body: CreateReviewDto) {
+    // 1) shop 존재 확인
+    const shop = await this.shopRepo.findById(shopId);
+    if (!shop) throw new NotFoundException('Shop not found');
+
+    // 2) 리뷰 + 이미지 한 트랜잭션에서 생성
+    const created = await this.txRunner.run(async (ctx) => {
+      const review = await this.reviewRepo.create(
+        {
+          shopId,
+          authorId: userId,
+          rating: body.rating,
+          content: body.content ?? null,
+        },
+        ctx,
+      );
+
+      if (body.imageUrls?.length) {
+        await this.reviewImagesRepo.createMany(
+          body.imageUrls.map((url, index) => ({
+            shopId,
+            reviewId: review.id,
+            uploaderId: userId,
+            url,
+            order: index,
+          })),
+          ctx,
+        );
+      }
+
+      const reviewWithImages = await this.reviewRepo.findById(review.id, ctx);
+
+      if (!reviewWithImages) {
+        throw new NotFoundException('Created review not found');
+      }
+
+      return reviewWithImages;
+    });
+
+    // 3) 응답 가공
+    return {
+      id: created.id,
+      rating: created.rating,
+      content: created.content,
+      createdAt: created.createdAt,
+
+      author: created.author
+        ? {
+            id: created.author.id,
+            nickname: created.author.nickname ?? null,
+            profileImageUrl: created.author.profileImageUrl ?? null,
+          }
+        : null,
+
+      images: created.images.map((img) => ({
+        id: img.id,
+        url: img.url,
+        order: img.order,
+      })),
+    };
   }
 }


### PR DESCRIPTION
## 개요
가게 상세 화면에서 사용자가 리뷰를 직접 등록할 수 있도록 리뷰 생성 API를 추가했습니다.
리뷰 등록은 인증된 사용자만 가능하도록 인증 가드를 적용했으며, 이미지 업로드는 프론트에서 처리하고 백엔드는 이미지 URL만 저장하는 구조로 설계했습니다.

또한 이미지 저장 방식에 대해 AWS S3와 Cloudinary를 비교 검토한 뒤 Cloudinary를 채택했습니다.

### 주요 변경 사항
1. 리뷰 생성 DTO 추가
- CreateReviewDto 추가
- 리뷰 등록 요청값 유효성 검증 적용
- rating: 1~5 정수
- content: optional
- imageUrls: optional string[]
- 최대 10장 제한
- URL 형식 검증
2. 리뷰 등록 API 추가
- reviews.controller.ts에 리뷰 생성 엔드포인트 추가
- 특정 가게 기준으로 리뷰 생성 가능
- 이미지 URL 배열 포함하여 저장 가능
3. 리뷰 서비스 로직 구현
- reviews.service.ts
- 가게 존재 여부 검증
- 리뷰 생성 처리
- 이미지 URL이 있는 경우 리뷰 이미지 함께 저장
4. Repository 계층 확장
- 리뷰 및 리뷰 이미지 저장을 위한 메서드 추가
- Prisma 기반 구현 확장
5. 인증 가드 적용
- auth/guards 추가
- 리뷰 등록 API는 인증된 사용자만 접근 가능하도록 제한
- auth.module.ts 수정
6. 모듈 구성 정리
- reviews.module.ts 수정
- 리뷰 생성 흐름에 필요한 의존성 연결

## 설계 결정: S3 대신 Cloudinary 선택 이유
이미지 업로드 및 저장 방식에 대해 다음 두 가지 옵션을 비교했습니다.
1. AWS S3
장점
- 높은 확장성
- 직접적인 저장 제어 가능
단점
- presigned URL 생성 필요 (백엔드 로직 추가 필요)
- 이미지 리사이징, 최적화 별도 구현 필요
- 초기 설정 및 운영 복잡도 존재
2. Cloudinary (채택)
장점
- 프론트에서 직접 업로드 가능 (unsigned upload)
- 별도의 백엔드 처리 없이 이미지 URL 확보 가능
- 이미지 최적화 및 리사이징 기능 내장
- 빠른 개발 및 낮은 구현 복잡도
단점
- 외부 서비스 의존성 존재
### 선택 이유
이번 프로젝트에서는 빠른 기능 구현, 프론트 중심 구조 이미지 업로드 로직 단순화를 우선으로 고려하여 Cloudinary를 선택했습니다.

그 결과:
- 백엔드는 이미지 파일을 처리하지 않고
- 이미 업로드된 URL만 저장하는 구조로 단순화
