### PR TITLE
[FEAT] 리뷰 생성 시 태그 선택 기능 추가 및 ReviewTag 집계 연동

### DIFF
--- a/src/modules/reviews/dto/create-review-dto.ts
+++ b/src/modules/reviews/dto/create-review-dto.ts
@@ -8,6 +8,7 @@ import {
   IsArray,
   ArrayMaxSize,
   IsUrl,
+  ArrayUnique,
 } from 'class-validator';
 
 export class CreateReviewDto {
@@ -26,4 +27,11 @@ export class CreateReviewDto {
   @ArrayMaxSize(10) // 최대 10장 제한
   @IsUrl({}, { each: true })
   imageUrls?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @ArrayUnique()
+  @IsString({ each: true })
+  tags?: string[];
 }

--- a/src/modules/reviews/interface/review-tags.repository.interface.ts
+++ b/src/modules/reviews/interface/review-tags.repository.interface.ts
@@ -15,4 +15,12 @@ export interface IReviewTagsRepository {
     shopId: string,
     ctx?: TransactionContext<Prisma.TransactionClient>,
   ): Promise<ReviewTagRecord[]>;
+
+  upsertAndIncreaseCount(
+    params: {
+      shopId: string;
+      label: string;
+    },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<void>;
 }

--- a/src/modules/reviews/repository/review-tags.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-tags.prisma.repository.ts
@@ -33,4 +33,36 @@ export class ReviewTagsPrismaRepository implements IReviewTagsRepository {
 
     return tags as ReviewTagRecord[];
   }
+
+  async upsertAndIncreaseCount(
+    params: {
+      shopId: string;
+      label: string;
+    },
+    ctx?: TransactionContext<Prisma.TransactionClient>,
+  ): Promise<void> {
+    const db = getDb(ctx, this.prisma);
+
+    await db.reviewTag.upsert({
+      where: {
+        shopId_label: {
+          shopId: params.shopId,
+          label: params.label,
+        },
+      },
+      create: {
+        shopId: params.shopId,
+        label: params.label,
+        count: 1,
+        externalCount: 0,
+        isActive: true,
+      },
+      update: {
+        count: {
+          increment: 1,
+        },
+        isActive: true,
+      },
+    });
+  }
 }

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -140,7 +140,7 @@ export class ReviewsService {
     const shop = await this.shopRepo.findById(shopId);
     if (!shop) throw new NotFoundException('Shop not found');
 
-    // 2) 리뷰 + 이미지 한 트랜잭션에서 생성
+    // 2) 리뷰 + 이미지 + 태그 집계 한 트랜잭션에서 처리
     const created = await this.txRunner.run(async (ctx) => {
       const review = await this.reviewRepo.create(
         {
@@ -163,6 +163,20 @@ export class ReviewsService {
           })),
           ctx,
         );
+      }
+
+      if (body.tags?.length) {
+        const uniqueTags = [...new Set(body.tags)];
+
+        for (const label of uniqueTags) {
+          await this.reviewTagsRepo.upsertAndIncreaseCount(
+            {
+              shopId,
+              label,
+            },
+            ctx,
+          );
+        }
       }
 
       const reviewWithImages = await this.reviewRepo.findById(review.id, ctx);

--- a/src/modules/shops/shops.controller.ts
+++ b/src/modules/shops/shops.controller.ts
@@ -33,7 +33,7 @@ export class ShopsController {
   }
 
   @Get(':shopId/menus')
-  async hetShopMenu(@Param('shopId') shopId: string) {
+  async getShopMenu(@Param('shopId') shopId: string) {
     const data = await this.shopsService.getShopMenus(shopId);
     return { success: true, data };
   }


### PR DESCRIPTION
## 개요
리뷰 등록 시 태그를 선택할 수 있도록 기능을 확장하고, 선택된 태그를 기반으로 가게별 태그 집계(ReviewTag)가 자동으로 반영되도록 구현했습니다.

---

## 주요 변경 사항

### 1. 리뷰 생성 API 확장
- CreateReviewDto에 `tags?: string[]` 필드 추가
- 리뷰 생성 시 태그 배열을 함께 전달받도록 구조 확장

### 2. 태그 집계 로직 추가
- 리뷰 등록 시 선택된 태그를 기반으로 `ReviewTag.count` 증가 처리
- `(shopId, label)` 기준으로 upsert 로직 구현
- 기존 태그 존재 시 count 증가, 없으면 생성

### 3. Repository 기능 확장
- `IReviewTagsRepository`에 `upsertAndIncreaseCount` 메서드 추가
- Prisma repository에서 upsert 기반 count 증가 로직 구현

### 4. 트랜잭션 처리 개선
- 리뷰 생성 + 이미지 생성 + 태그 집계 증가를 하나의 트랜잭션으로 묶어 데이터 정합성 보장

### 5. 데이터 안정성 보완
- 태그 중복 선택 방지를 위한 Set 처리 적용

---

## API 변경 사항

### POST /shops/:shopId/reviews

#### Request Body (추가)
```json
{
  "rating": 5,
  "content": "빵이 맛있어요",
  "imageUrls": [],
  "tags": ["빵이 맛있어요", "친절해요"]
}