### PR TITLE
fix: 리뷰 응답에 author.displayName 추가

### DIFF
--- a/src/modules/reviews/interface/reviews.repository.interface.ts
+++ b/src/modules/reviews/interface/reviews.repository.interface.ts
@@ -17,6 +17,7 @@ export type ReviewListItemRecord = Prisma.ReviewGetPayload<{
       select: {
         id: true;
         nickname: true;
+        displayName: true;
         profileImageUrl: true;
       };
     };
@@ -41,6 +42,7 @@ export type ReviewDetailRecord = Prisma.ReviewGetPayload<{
       select: {
         id: true;
         nickname: true;
+        displayName: true;
         profileImageUrl: true;
       };
     };

--- a/src/modules/reviews/repository/reviews.prisma.repository.ts
+++ b/src/modules/reviews/repository/reviews.prisma.repository.ts
@@ -54,6 +54,7 @@ export class ReviewsPrismaRepository implements IReviewsRepository {
           select: {
             id: true,
             nickname: true,
+            displayName: true,
             profileImageUrl: true,
           },
         },
@@ -107,6 +108,7 @@ export class ReviewsPrismaRepository implements IReviewsRepository {
           select: {
             id: true,
             nickname: true,
+            displayName: true,
             profileImageUrl: true,
           },
         },

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -98,6 +98,7 @@ export class ReviewsService {
         ? {
             id: r.author.id,
             nickname: r.author.nickname ?? null,
+            displayName: r.author.displayName ?? null,
             profileImageUrl: r.author.profileImageUrl ?? null,
           }
         : null,
@@ -214,6 +215,7 @@ export class ReviewsService {
         ? {
             id: created.author.id,
             nickname: created.author.nickname ?? null,
+            displayName: created.author.displayName ?? null,
             profileImageUrl: created.author.profileImageUrl ?? null,
           }
         : null,


### PR DESCRIPTION
## Summary
- 리뷰 조회(`GET /shops/:shopId/reviews`) 및 리뷰 작성 응답의 `author` 필드에 `displayName` 추가
- 기존에 `nickname`만 내려줬는데, 대부분 유저가 nickname 미설정 상태라 프론트에서 "익명사용자"로 표시되던 문제 수정

## 변경 파일
- `reviews.repository.interface.ts` — `ReviewListItemRecord`, `ReviewDetailRecord`에 `displayName` 추가
- `reviews.prisma.repository.ts` — author select에 `displayName` 추가
- `reviews.service.ts` — 응답 가공 시 `displayName` 포함

## 프론트 사용 방법
```js
const authorName = author.nickname ?? author.displayName ?? '익명사용자'
```

## Test plan
- [x] `GET /shops/:shopId/reviews` 응답 `items[0].author.displayName` 확인
- [x] 리뷰 작성 후 응답 `author.displayName` 확인

## 대응 RN PR
https://github.com/saltbreads/saltbread-rn-test/pull/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)