### PR TITLE
feat: RN 토큰 갱신 플로우 지원 및 refreshToken 슬라이딩 만료

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -88,9 +88,13 @@ export class AuthController {
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   async refresh(@Req() req: Request, @Res() res: Response) {
-    const refreshToken = req.cookies?.['refresh_token'] as string | undefined;
+    const isMobile = req.headers['x-client-type'] === 'mobile';
+    const bodyToken = (req.body as { refreshToken?: string })?.refreshToken;
+    const refreshToken =
+      (isMobile && bodyToken) || req.cookies?.['refresh_token'] as string | undefined;
+
     if (!refreshToken) {
-      throw new UnauthorizedException('No refresh cookie');
+      throw new UnauthorizedException('No refresh token');
     }
 
     const {
@@ -106,6 +110,7 @@ export class AuthController {
       data: {
         accessToken,
         sessionId,
+        ...(isMobile && { refreshToken: newRefreshToken }),
       },
     });
   }
@@ -140,6 +145,7 @@ export class AuthController {
       data: {
         accessToken,
         sessionId,
+        ...(req.headers['x-client-type'] === 'mobile' && { refreshToken }),
       },
     });
   }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -149,11 +149,12 @@ export class AuthService {
       throw new UnauthorizedException('Refresh token reused/invalid');
     }
 
-    // rotation: 새 refresh 발급 + 해시 갱신
+    // rotation: 새 refresh 발급 + 해시 갱신 + 만료일 슬라이딩
     const newRefreshToken = this.signRefreshToken(userId, session.id);
     const newHash = await this.hashToken(newRefreshToken);
+    const newExpiresAt = this.parseRefreshExpiryDate();
 
-    await this.sessionRepo.updateRefreshHash(session.id, newHash);
+    await this.sessionRepo.updateRefreshHash(session.id, newHash, newExpiresAt);
 
     const newAccessToken = this.signAccessToken(userId);
 

--- a/src/modules/auth/interface/session.repository.interface.ts
+++ b/src/modules/auth/interface/session.repository.interface.ts
@@ -19,6 +19,6 @@ export interface ISessionRepository {
     refreshTokenHash: string;
     expiresAt: Date;
   } | null>;
-  updateRefreshHash(sessionId: string, newHash: string): Promise<void>;
+  updateRefreshHash(sessionId: string, newHash: string, expiresAt: Date): Promise<void>;
   deleteById(id: string): Promise<void>;
 }

--- a/src/modules/auth/repositories/session.repository.prisma.ts
+++ b/src/modules/auth/repositories/session.repository.prisma.ts
@@ -37,10 +37,10 @@ export class SessionPrismaRepository implements ISessionRepository {
     });
   }
 
-  async updateRefreshHash(sessionId: string, newHash: string): Promise<void> {
+  async updateRefreshHash(sessionId: string, newHash: string, expiresAt: Date): Promise<void> {
     await this.prisma.authSession.update({
       where: { id: sessionId },
-      data: { refreshTokenHash: newHash },
+      data: { refreshTokenHash: newHash, expiresAt },
     });
   }
 


### PR DESCRIPTION
## Summary
- `X-Client-Type: mobile` 헤더 기반으로 RN 전용 토큰 발급 플로우 추가
- refreshToken 슬라이딩 만료 적용 — 앱 사용 중 로그아웃 방지
- 웹 기존 HttpOnly 쿠키 플로우 완전 유지

## 변경 내용

### `POST /auth/exchange`
`X-Client-Type: mobile` 헤더 있을 때만 응답 body에 `refreshToken` 추가

### `POST /auth/refresh`
- 모바일 헤더 시 body의 `{ refreshToken }` 수락 (쿠키 없어도 동작)
- 모바일 헤더 시 응답 body에 새 `refreshToken` 포함 (rotation)

### refreshToken 슬라이딩 만료
`rotateRefresh` 호출 시 세션 `expiresAt`을 현재 기준 7일로 연장

## 변경 파일
- `auth.controller.ts` — 헤더 감지 및 조건부 토큰 응답
- `auth.service.ts` — `rotateRefresh`에서 슬라이딩 만료 처리
- `session.repository.interface.ts` — `updateRefreshHash` 시그니처에 `expiresAt` 추가
- `session.repository.prisma.ts` — `expiresAt` 갱신 쿼리 추가

## RN 플로우
```
API 호출 → 401
    ↓
POST /auth/refresh
  Headers: { X-Client-Type: mobile }
  Body: { refreshToken }
    ↓
성공 → 새 토큰 저장 후 원래 요청 재시도
실패 → 로그아웃
```

## Test plan
- [x] `X-Client-Type: mobile` 헤더로 exchange 시 body에 refreshToken 포함 확인
- [x] body의 refreshToken으로 refresh 호출 성공 확인
- [x] 헤더 없이 요청 시 기존 쿠키 방식 동일하게 동작 확인
- [x] RN에서 401 후 자동 갱신 및 재시도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)