### PR TITLE
feat: 찜 목록 응답에 roadAddress, avgRating, reviewCount 추가

### DIFF
--- a/src/modules/favorites/interface/favorite.repository.interface.ts
+++ b/src/modules/favorites/interface/favorite.repository.interface.ts
@@ -5,6 +5,9 @@ export type FavoriteShopItem = {
   name: string;
   heroImageUrl: string | null;
   region: string;
+  roadAddress: string | null;
+  avgRating: number | null;
+  reviewCount: number;
   createdAt: Date;
 };
 

--- a/src/modules/favorites/repositories/favorite.repository.prisma.ts
+++ b/src/modules/favorites/repositories/favorite.repository.prisma.ts
@@ -30,6 +30,7 @@ export class FavoritePrismaRepository implements IFavoriteRepository {
             name: true,
             heroImageUrl: true,
             region: true,
+            roadAddress: true,
           },
         },
         createdAt: true,
@@ -37,12 +38,41 @@ export class FavoritePrismaRepository implements IFavoriteRepository {
       orderBy: { createdAt: 'desc' },
     });
 
-    return favorites.map((f) => ({
-      shopId: f.shop.id,
-      name: f.shop.name,
-      heroImageUrl: f.shop.heroImageUrl,
-      region: f.shop.region,
-      createdAt: f.createdAt,
-    }));
+    if (favorites.length === 0) return [];
+
+    const shopIds = favorites.map((f) => f.shop.id);
+
+    const reviewStats = await this.prisma.review.groupBy({
+      by: ['shopId'],
+      where: { shopId: { in: shopIds }, isHidden: false },
+      _count: { id: true },
+      _avg: { rating: true },
+    });
+
+    const statsMap = new Map(
+      reviewStats.map((s) => [
+        s.shopId,
+        {
+          reviewCount: s._count.id,
+          avgRating: s._avg.rating
+            ? Math.round(s._avg.rating * 10) / 10
+            : null,
+        },
+      ]),
+    );
+
+    return favorites.map((f) => {
+      const stats = statsMap.get(f.shop.id);
+      return {
+        shopId: f.shop.id,
+        name: f.shop.name,
+        heroImageUrl: f.shop.heroImageUrl,
+        region: f.shop.region,
+        roadAddress: f.shop.roadAddress,
+        avgRating: stats?.avgRating ?? null,
+        reviewCount: stats?.reviewCount ?? 0,
+        createdAt: f.createdAt,
+      };
+    });
   }
 }


### PR DESCRIPTION
## Summary
`GET /users/me/favorites` 각 아이템에 가게 상세 정보 및 리뷰 통계 추가

## 변경 내용
- `FavoriteShopItem` 타입에 `roadAddress`, `avgRating`, `reviewCount` 추가
- `findByUserId`에서 찜 목록 조회 후 shopId 배치 쿼리로 리뷰 통계 합산 (N+1 없음)

## 변경된 응답
```json
{
  "shopId": "...",
  "name": "카프리쵸사",
  "heroImageUrl": "...",
  "region": "대구",
  "roadAddress": "대구 달성군 ...",
  "avgRating": 4.6,
  "reviewCount": 23,
  "createdAt": "..."
}
```
- `roadAddress` — 없으면 `null`
- `avgRating` — 리뷰 없으면 `null`, 소수점 1자리
- `reviewCount` — 리뷰 없으면 `0`

## 변경 파일
- `favorites/interface/favorite.repository.interface.ts` — 타입 필드 추가
- `favorites/repositories/favorite.repository.prisma.ts` — shop select 및 리뷰 통계 배치 쿼리 추가

## Test plan
- [x] `GET /users/me/favorites` → `roadAddress`, `avgRating`, `reviewCount` 포함 확인
- [x] 리뷰 없는 가게 → `avgRating: null`, `reviewCount: 0` 확인
- [x] 리뷰 있는 가게 → 정상 값 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)