### PR TITLE
feat: 리뷰 댓글 및 좋아요 기능 추가

### DIFF
--- a/prisma/migrations/20260510094434_add_review_comment_like/migration.sql
+++ b/prisma/migrations/20260510094434_add_review_comment_like/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable
+CREATE TABLE "ReviewComment" (
+    "id" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReviewComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ReviewLike" (
+    "id" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReviewLike_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ReviewComment_reviewId_createdAt_idx" ON "ReviewComment"("reviewId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ReviewComment_authorId_idx" ON "ReviewComment"("authorId");
+
+-- CreateIndex
+CREATE INDEX "ReviewLike_reviewId_idx" ON "ReviewLike"("reviewId");
+
+-- CreateIndex
+CREATE INDEX "ReviewLike_userId_idx" ON "ReviewLike"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReviewLike_reviewId_userId_key" ON "ReviewLike"("reviewId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "ReviewComment" ADD CONSTRAINT "ReviewComment_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewComment" ADD CONSTRAINT "ReviewComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewLike" ADD CONSTRAINT "ReviewLike_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewLike" ADD CONSTRAINT "ReviewLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,8 @@ model User {
   reviews Review[]
   reviewImages ReviewImage[]
   favorites UserFavorite[]
+  reviewComments ReviewComment[]
+  reviewLikes ReviewLike[]
 
   @@unique([provider, providerUserId])
   @@index([provider])
@@ -161,10 +163,45 @@ model Review {
   updatedAt DateTime @updatedAt
 
   // 연결
-  images ReviewImage[]
+  images   ReviewImage[]
+  comments ReviewComment[]
+  likes    ReviewLike[]
 
   @@index([shopId, createdAt])
   @@index([shopId, rating])
+}
+
+model ReviewComment {
+  id       String @id @default(cuid())
+
+  reviewId String
+  review   Review @relation(fields: [reviewId], references: [id], onDelete: Cascade)
+
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
+
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([reviewId, createdAt])
+  @@index([authorId])
+}
+
+model ReviewLike {
+  id       String @id @default(cuid())
+
+  reviewId String
+  review   Review @relation(fields: [reviewId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([reviewId, userId])
+  @@index([reviewId])
+  @@index([userId])
 }
 
 model ReviewTag {

--- a/src/modules/auth/guards/optional-jwt-auth.guard.ts
+++ b/src/modules/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,37 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { Request } from 'express';
+import type { AuthPrincipal } from '../types/auth-pricncipal';
+
+type AccessPayload = { sub: string };
+type AuthenticatedRequest = Request & { user?: AuthPrincipal };
+
+@Injectable()
+export class OptionalJwtAuthGuard implements CanActivate {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const authorization = request.headers.authorization;
+
+    if (!authorization) return true;
+
+    const [type, token] = authorization.split(' ');
+    if (type !== 'Bearer' || !token) return true;
+
+    try {
+      const payload = await this.jwtService.verifyAsync<AccessPayload>(token, {
+        secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
+      });
+      request.user = { userId: payload.sub };
+    } catch {
+      // 만료/위조된 토큰도 에러 없이 통과 (isLikedByMe: false 처리)
+    }
+
+    return true;
+  }
+}

--- a/src/modules/reviews/interface/review-interactions.repository.interface.ts
+++ b/src/modules/reviews/interface/review-interactions.repository.interface.ts
@@ -1,0 +1,27 @@
+export const REVIEW_COMMENT_REPOSITORY = Symbol('REVIEW_COMMENT_REPOSITORY');
+export const REVIEW_LIKE_REPOSITORY = Symbol('REVIEW_LIKE_REPOSITORY');
+
+export type ReviewCommentRecord = {
+  id: string;
+  content: string;
+  createdAt: Date;
+  author: {
+    id: string;
+    nickname: string | null;
+    displayName: string | null;
+    profileImageUrl: string | null;
+  };
+};
+
+export interface IReviewCommentRepository {
+  create(data: { reviewId: string; authorId: string; content: string }): Promise<ReviewCommentRecord>;
+  delete(commentId: string, authorId: string): Promise<void>;
+  findPageByReviewId(reviewId: string, args: { skip: number; take: number }): Promise<ReviewCommentRecord[]>;
+  countByReviewId(reviewId: string): Promise<number>;
+}
+
+export interface IReviewLikeRepository {
+  add(reviewId: string, userId: string): Promise<void>;
+  remove(reviewId: string, userId: string): Promise<void>;
+  getLikedReviewIds(userId: string, reviewIds: string[]): Promise<string[]>;
+}

--- a/src/modules/reviews/interface/reviews.repository.interface.ts
+++ b/src/modules/reviews/interface/reviews.repository.interface.ts
@@ -28,6 +28,29 @@ export type ReviewListItemRecord = Prisma.ReviewGetPayload<{
         order: true;
       };
     };
+    _count: {
+      select: {
+        likes: true;
+        comments: true;
+      };
+    };
+    comments: {
+      select: {
+        id: true;
+        content: true;
+        createdAt: true;
+        author: {
+          select: {
+            id: true;
+            nickname: true;
+            displayName: true;
+            profileImageUrl: true;
+          };
+        };
+      };
+      orderBy: { createdAt: 'desc' };
+      take: 3;
+    };
   };
 }>;
 

--- a/src/modules/reviews/repository/review-interactions.prisma.repository.ts
+++ b/src/modules/reviews/repository/review-interactions.prisma.repository.ts
@@ -1,0 +1,94 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/shared/prisma/prisma.service';
+import type {
+  IReviewCommentRepository,
+  IReviewLikeRepository,
+  ReviewCommentRecord,
+} from '../interface/review-interactions.repository.interface';
+
+@Injectable()
+export class ReviewCommentPrismaRepository implements IReviewCommentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: { reviewId: string; authorId: string; content: string }): Promise<ReviewCommentRecord> {
+    return this.prisma.reviewComment.create({
+      data,
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        author: {
+          select: {
+            id: true,
+            nickname: true,
+            displayName: true,
+            profileImageUrl: true,
+          },
+        },
+      },
+    });
+  }
+
+  async delete(commentId: string, authorId: string): Promise<void> {
+    const comment = await this.prisma.reviewComment.findUnique({
+      where: { id: commentId },
+      select: { authorId: true },
+    });
+
+    if (!comment) throw new NotFoundException('댓글을 찾을 수 없습니다.');
+    if (comment.authorId !== authorId) throw new NotFoundException('댓글을 찾을 수 없습니다.');
+
+    await this.prisma.reviewComment.delete({ where: { id: commentId } });
+  }
+
+  async findPageByReviewId(reviewId: string, args: { skip: number; take: number }): Promise<ReviewCommentRecord[]> {
+    return this.prisma.reviewComment.findMany({
+      where: { reviewId },
+      skip: args.skip,
+      take: args.take,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        author: {
+          select: {
+            id: true,
+            nickname: true,
+            displayName: true,
+            profileImageUrl: true,
+          },
+        },
+      },
+    });
+  }
+
+  async countByReviewId(reviewId: string): Promise<number> {
+    return this.prisma.reviewComment.count({ where: { reviewId } });
+  }
+}
+
+@Injectable()
+export class ReviewLikePrismaRepository implements IReviewLikeRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async add(reviewId: string, userId: string): Promise<void> {
+    await this.prisma.reviewLike.upsert({
+      where: { reviewId_userId: { reviewId, userId } },
+      create: { reviewId, userId },
+      update: {},
+    });
+  }
+
+  async remove(reviewId: string, userId: string): Promise<void> {
+    await this.prisma.reviewLike.deleteMany({ where: { reviewId, userId } });
+  }
+
+  async getLikedReviewIds(userId: string, reviewIds: string[]): Promise<string[]> {
+    const likes = await this.prisma.reviewLike.findMany({
+      where: { userId, reviewId: { in: reviewIds } },
+      select: { reviewId: true },
+    });
+    return likes.map((l) => l.reviewId);
+  }
+}

--- a/src/modules/reviews/repository/reviews.prisma.repository.ts
+++ b/src/modules/reviews/repository/reviews.prisma.repository.ts
@@ -115,12 +115,28 @@ export class ReviewsPrismaRepository implements IReviewsRepository {
           },
         },
         images: {
+          select: { id: true, url: true, order: true },
+          orderBy: [{ order: 'asc' }, { id: 'asc' }],
+        },
+        _count: {
+          select: { likes: true, comments: true },
+        },
+        comments: {
           select: {
             id: true,
-            url: true,
-            order: true,
+            content: true,
+            createdAt: true,
+            author: {
+              select: {
+                id: true,
+                nickname: true,
+                displayName: true,
+                profileImageUrl: true,
+              },
+            },
           },
-          orderBy: [{ order: 'asc' }, { id: 'asc' }],
+          orderBy: { createdAt: 'desc' as const },
+          take: 3,
         },
       },
     });

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -2,33 +2,38 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Req,
   Body,
   Param,
   Query,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { ReviewsService } from './reviews.service';
 import { GetShopReviewsQueryDto } from './dto/get-shop-reviews-query-dto';
 import { CreateReviewDto } from './dto/create-review-dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import { SuggestReviewTagsDto } from './dto/suggest-review-tags-dto';
+import type { AuthPrincipal } from '../auth/types/auth-pricncipal';
 
 @Controller()
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
 
   @Get('shops/:shopId/reviews')
+  @UseGuards(OptionalJwtAuthGuard)
   async getShopReviews(
     @Param('shopId') shopId: string,
     @Query() query: GetShopReviewsQueryDto,
+    @Req() req: Request,
   ) {
-    const data = await this.reviewsService.getShopReviews(shopId, query);
-
-    return {
-      success: true,
-      data,
-    };
+    const userId = (req.user as AuthPrincipal | undefined)?.userId;
+    const data = await this.reviewsService.getShopReviews(shopId, query, userId);
+    return { success: true, data };
   }
 
   @Get('shops/:shopId/review-tags')
@@ -37,33 +42,82 @@ export class ReviewsController {
     return { success: true, data };
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('shops/:shopId/reviews')
+  @UseGuards(JwtAuthGuard)
   async createReview(
     @Param('shopId') shopId: string,
     @Body() body: CreateReviewDto,
-    @Req() req: { user: { userId: string } },
+    @Req() req: Request,
   ) {
-    const data = await this.reviewsService.createReview(
-      shopId,
-      req.user.userId,
-      body,
-    );
-
-    return {
-      success: true,
-      data,
-    };
+    const user = req.user as AuthPrincipal;
+    const data = await this.reviewsService.createReview(shopId, user.userId, body);
+    return { success: true, data };
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('reviews/ai-tag-suggestions')
+  @UseGuards(JwtAuthGuard)
   async suggestReviewTags(@Body() dto: SuggestReviewTagsDto) {
     const data = await this.reviewsService.suggestReviewTags(dto);
+    return { success: true, data };
+  }
 
-    return {
-      success: true,
-      data,
-    };
+  // 댓글
+  @Post('reviews/:reviewId/comments')
+  @UseGuards(JwtAuthGuard)
+  async addComment(
+    @Param('reviewId') reviewId: string,
+    @Body('content') content: string,
+    @Req() req: Request,
+  ) {
+    const user = req.user as AuthPrincipal;
+    const data = await this.reviewsService.addComment(reviewId, user.userId, content);
+    return { success: true, data };
+  }
+
+  @Delete('reviews/comments/:commentId')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteComment(
+    @Param('commentId') commentId: string,
+    @Req() req: Request,
+  ) {
+    const user = req.user as AuthPrincipal;
+    await this.reviewsService.deleteComment(commentId, user.userId);
+  }
+
+  @Get('reviews/:reviewId/comments')
+  async getComments(
+    @Param('reviewId') reviewId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const data = await this.reviewsService.getComments(reviewId, {
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+    return { success: true, data };
+  }
+
+  // 좋아요
+  @Post('reviews/:reviewId/like')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async addLike(
+    @Param('reviewId') reviewId: string,
+    @Req() req: Request,
+  ) {
+    const user = req.user as AuthPrincipal;
+    await this.reviewsService.addLike(reviewId, user.userId);
+  }
+
+  @Delete('reviews/:reviewId/like')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeLike(
+    @Param('reviewId') reviewId: string,
+    @Req() req: Request,
+  ) {
+    const user = req.user as AuthPrincipal;
+    await this.reviewsService.removeLike(reviewId, user.userId);
   }
 }

--- a/src/modules/reviews/reviews.module.ts
+++ b/src/modules/reviews/reviews.module.ts
@@ -8,6 +8,14 @@ import { REVIEW_TAGS_REPOSITORY } from './interface/review-tags.repository.inter
 import { ReviewTagsPrismaRepository } from './repository/review-tags.prisma.repository';
 import { REVIEW_IMAGES_REPOSITORY } from './interface/review-images.repository.interface';
 import { ReviewImagesPrismaRepository } from './repository/review-images.prisma.repository';
+import {
+  REVIEW_COMMENT_REPOSITORY,
+  REVIEW_LIKE_REPOSITORY,
+} from './interface/review-interactions.repository.interface';
+import {
+  ReviewCommentPrismaRepository,
+  ReviewLikePrismaRepository,
+} from './repository/review-interactions.prisma.repository';
 import { AuthModule } from '../auth/auth.module';
 import { AiModule } from '../ai/ai.modlue';
 
@@ -27,6 +35,14 @@ import { AiModule } from '../ai/ai.modlue';
     {
       provide: REVIEW_IMAGES_REPOSITORY,
       useClass: ReviewImagesPrismaRepository,
+    },
+    {
+      provide: REVIEW_COMMENT_REPOSITORY,
+      useClass: ReviewCommentPrismaRepository,
+    },
+    {
+      provide: REVIEW_LIKE_REPOSITORY,
+      useClass: ReviewLikePrismaRepository,
     },
   ],
   exports: [REVIEW_IMAGES_REPOSITORY],

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -35,6 +35,12 @@ import {
   REVIEWS_REPOSITORY,
   type IReviewsRepository,
 } from './interface/reviews.repository.interface';
+import {
+  REVIEW_COMMENT_REPOSITORY,
+  REVIEW_LIKE_REPOSITORY,
+  type IReviewCommentRepository,
+  type IReviewLikeRepository,
+} from './interface/review-interactions.repository.interface';
 import { REVIEW_TAGS } from './constants/review-tags-constants';
 @Injectable()
 export class ReviewsService {
@@ -56,9 +62,15 @@ export class ReviewsService {
 
     @Inject(OPENAI_TAG_SUGGESTION_SERVICE)
     private readonly openAiTagSuggestionService: IOpenAiTagSuggestionService,
+
+    @Inject(REVIEW_COMMENT_REPOSITORY)
+    private readonly reviewCommentRepo: IReviewCommentRepository,
+
+    @Inject(REVIEW_LIKE_REPOSITORY)
+    private readonly reviewLikeRepo: IReviewLikeRepository,
   ) {}
 
-  async getShopReviews(shopId: string, query: GetShopReviewsQueryDto) {
+  async getShopReviews(shopId: string, query: GetShopReviewsQueryDto, userId?: string) {
     // 1) shop 존재 확인 (명확한 404)
     const shop = await this.shopRepo.findById(shopId);
     if (!shop) throw new NotFoundException('Shop not found');
@@ -87,12 +99,22 @@ export class ReviewsService {
       return { total, items };
     });
 
-    // 5) 응답 가공 (필드명은 너희 Review select/include에 맞춰 조정)
+    // 5) isLikedByMe 배치 조회
+    const reviewIds = items.map((r) => r.id);
+    const likedIds = userId && reviewIds.length
+      ? await this.reviewLikeRepo.getLikedReviewIds(userId, reviewIds)
+      : [];
+    const likedSet = new Set(likedIds);
+
+    // 6) 응답 가공
     const reviews = items.map((r: ReviewListItemRecord) => ({
       id: r.id,
       rating: r.rating,
       content: r.content,
       createdAt: r.createdAt,
+      likeCount: r._count.likes,
+      commentCount: r._count.comments,
+      isLikedByMe: likedSet.has(r.id),
 
       author: r.author
         ? {
@@ -108,6 +130,18 @@ export class ReviewsService {
         url: img.url,
         order: img.order,
       })),
+
+      comments: r.comments.map((c) => ({
+        id: c.id,
+        content: c.content,
+        createdAt: c.createdAt,
+        author: {
+          id: c.author.id,
+          nickname: c.author.nickname ?? null,
+          displayName: c.author.displayName ?? null,
+          profileImageUrl: c.author.profileImageUrl ?? null,
+        },
+      })),
     }));
 
     return {
@@ -117,6 +151,35 @@ export class ReviewsService {
       total,
       hasNext: page * limit < total,
     };
+  }
+
+  async addComment(reviewId: string, authorId: string, content: string) {
+    return this.reviewCommentRepo.create({ reviewId, authorId, content });
+  }
+
+  async deleteComment(commentId: string, authorId: string) {
+    return this.reviewCommentRepo.delete(commentId, authorId);
+  }
+
+  async getComments(reviewId: string, query: { page?: number; limit?: number }) {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await Promise.all([
+      this.reviewCommentRepo.findPageByReviewId(reviewId, { skip, take: limit }),
+      this.reviewCommentRepo.countByReviewId(reviewId),
+    ]);
+
+    return { items, page, limit, total, hasNext: page * limit < total };
+  }
+
+  async addLike(reviewId: string, userId: string) {
+    return this.reviewLikeRepo.add(reviewId, userId);
+  }
+
+  async removeLike(reviewId: string, userId: string) {
+    return this.reviewLikeRepo.remove(reviewId, userId);
   }
 
   // TODO:

--- a/src/modules/users/interface/user.repository.interface.ts
+++ b/src/modules/users/interface/user.repository.interface.ts
@@ -18,6 +18,15 @@ export type MyReviewItem = {
   images: { id: string; url: string; order: number }[];
   shop: { id: string; name: string; roadAddress: string | null; heroImageUrl: string | null };
   createdAt: Date;
+  likeCount: number;
+  commentCount: number;
+  isLikedByMe: boolean;
+  comments: {
+    id: string;
+    content: string;
+    createdAt: Date;
+    author: { id: string; nickname: string | null; displayName: string | null; profileImageUrl: string | null };
+  }[];
 };
 
 export type MyReviewStats = {

--- a/src/modules/users/repositories/user.repository.prisma.ts
+++ b/src/modules/users/repositories/user.repository.prisma.ts
@@ -84,7 +84,7 @@ export class UserPrismaRepository implements IUserRepository {
   }
 
   async findMyReviews(userId: string, args: { skip: number; take: number }): Promise<MyReviewItem[]> {
-    return this.prisma.review.findMany({
+    const rows = await this.prisma.review.findMany({
       where: { authorId: userId, isHidden: false },
       skip: args.skip,
       take: args.take,
@@ -107,8 +107,61 @@ export class UserPrismaRepository implements IUserRepository {
           select: { id: true, url: true, order: true },
           orderBy: [{ order: 'asc' }, { id: 'asc' }],
         },
+        _count: {
+          select: { likes: true, comments: true },
+        },
+        comments: {
+          select: {
+            id: true,
+            content: true,
+            createdAt: true,
+            author: {
+              select: {
+                id: true,
+                nickname: true,
+                displayName: true,
+                profileImageUrl: true,
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' as const },
+          take: 3,
+        },
       },
     });
+
+    const reviewIds = rows.map((r) => r.id);
+    const likedRows = reviewIds.length
+      ? await this.prisma.reviewLike.findMany({
+          where: { userId, reviewId: { in: reviewIds } },
+          select: { reviewId: true },
+        })
+      : [];
+    const likedSet = new Set(likedRows.map((l) => l.reviewId));
+
+    return rows.map((r) => ({
+      id: r.id,
+      rating: r.rating,
+      content: r.content,
+      tags: r.tags,
+      images: r.images,
+      shop: r.shop,
+      createdAt: r.createdAt,
+      likeCount: r._count.likes,
+      commentCount: r._count.comments,
+      isLikedByMe: likedSet.has(r.id),
+      comments: r.comments.map((c) => ({
+        id: c.id,
+        content: c.content,
+        createdAt: c.createdAt,
+        author: {
+          id: c.author.id,
+          nickname: c.author.nickname ?? null,
+          displayName: c.author.displayName ?? null,
+          profileImageUrl: c.author.profileImageUrl ?? null,
+        },
+      })),
+    }));
   }
 
   async countMyReviews(userId: string): Promise<number> {


### PR DESCRIPTION
## Summary
리뷰에 댓글 작성/삭제/조회와 좋아요 추가/취소 기능 구현.
리뷰 목록 응답에 likeCount, commentCount, isLikedByMe, comments(최신 3개) 추가.

## 새로운 DB 모델
- `ReviewComment` — 리뷰 댓글 (reviewId, authorId, content)
- `ReviewLike` — 리뷰 좋아요 (reviewId, userId, unique 제약)

## 새로운 엔드포인트

| 메서드 | 엔드포인트 | 설명 | 인증 |
|--------|-----------|------|------|
| `POST` | `/reviews/:reviewId/comments` | 댓글 작성 | JWT 필요 |
| `DELETE` | `/reviews/comments/:commentId` | 댓글 삭제 (본인만) | JWT 필요 |
| `GET` | `/reviews/:reviewId/comments` | 전체 댓글 목록 | 불필요 |
| `POST` | `/reviews/:reviewId/like` | 좋아요 | JWT 필요 |
| `DELETE` | `/reviews/:reviewId/like` | 좋아요 취소 | JWT 필요 |

## 변경된 엔드포인트
- `GET /shops/:shopId/reviews` — 옵셔널 인증 적용 (`OptionalJwtAuthGuard`)
  - 추가 필드: `likeCount`, `commentCount`, `isLikedByMe`, `comments`(최신 3개)
- `GET /users/me/reviews` — 동일 필드 추가

## 추가된 파일
- `optional-jwt-auth.guard.ts` — 토큰 있으면 user 세팅, 없으면 에러 없이 통과
- `review-interactions.repository.interface.ts` — 댓글/좋아요 레포지토리 인터페이스
- `review-interactions.prisma.repository.ts` — Prisma 구현체

## ⚠️ 팀원 필수 작업
```bash
npx prisma migrate deploy
```

## Test plan
- [x] 댓글 작성/삭제/목록 정상 동작
- [x] 좋아요 추가/취소 → likeCount 반영 확인
- [x] 토큰 없이 리뷰 목록 → isLikedByMe: false 확인
- [x] 토큰 있이 리뷰 목록 → isLikedByMe 정확히 반환
- [x] 타인 댓글 삭제 시도 → 404 확인
- [x] GET /users/me/reviews → 새 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)